### PR TITLE
feat(contract): dispute escrow flow + dispute_reason field + tests

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -64,7 +64,7 @@ pub enum DataKey {
 #[contracttype]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum EscrowStatus {
-    Pending = 0,
+    Active = 0,
     Released = 1,
     Refunded = 2,
     Disputed = 3,
@@ -91,6 +91,7 @@ pub struct Escrow {
     pub created_at: u32,
     pub ipfs_hash: Option<String>,
     pub metadata_hash: Option<Bytes>,
+    pub dispute_reason: Option<String>,
 }
 
 #[contracttype]
@@ -124,6 +125,7 @@ pub struct FundsRefundedEvent {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowDisputedEvent {
     pub escrow_id: u64,
+    pub dispute_reason: String,
 }
 
 #[contracttype]
@@ -131,6 +133,10 @@ pub struct EscrowDisputedEvent {
 pub struct EscrowResolvedEvent {
     pub escrow_id: u64,
     pub resolution: Resolution,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct EscrowMetadata {
     pub ipfs_hash: Option<String>,
     pub metadata_hash: Option<Bytes>,
@@ -293,11 +299,12 @@ impl EscrowContract {
             seller: seller.clone(),
             token: token.clone(),
             amount,
-            status: EscrowStatus::Pending,
+            status: EscrowStatus::Active,
             release_window: window,
             created_at,
             ipfs_hash: ipfs_hash.clone(),
             metadata_hash: metadata_hash.clone(),
+            dispute_reason: None,
         };
 
         env.storage()
@@ -412,7 +419,7 @@ impl EscrowContract {
         // Only buyer can release funds
         escrow.buyer.require_auth();
         
-        if !(escrow.status == EscrowStatus::Pending) { env.panic_with_error(Error::InvalidEscrowState); }
+        if !(escrow.status == EscrowStatus::Active) { env.panic_with_error(Error::InvalidEscrowState); }
 
         // Get platform config
         let config = Self::get_platform_config(&env);
@@ -470,7 +477,7 @@ impl EscrowContract {
         if !(escrow_opt.is_some()) { env.panic_with_error(Error::EscrowNotFound); }
         let mut escrow: Escrow = escrow_opt.unwrap();
 
-        if !(escrow.status == EscrowStatus::Pending) { env.panic_with_error(Error::InvalidEscrowState); }
+        if !(escrow.status == EscrowStatus::Active) { env.panic_with_error(Error::InvalidEscrowState); }
 
         let current_time = env.ledger().timestamp();
         let elapsed = current_time - (escrow.created_at as u64);
@@ -542,7 +549,7 @@ impl EscrowContract {
             env.panic_with_error(Error::Unauthorized);
         }
 
-        if !(escrow.status == EscrowStatus::Pending) { env.panic_with_error(Error::InvalidEscrowState); }
+        if !(escrow.status == EscrowStatus::Active) { env.panic_with_error(Error::InvalidEscrowState); }
 
         // Update status
         escrow.status = EscrowStatus::Refunded;
@@ -621,7 +628,7 @@ impl EscrowContract {
         if !(escrow_opt.is_some()) { env.panic_with_error(Error::EscrowNotFound); }
         let escrow: Escrow = escrow_opt.unwrap();
 
-        if escrow.status != EscrowStatus::Pending {
+        if escrow.status != EscrowStatus::Active {
             return false;
         }
 
@@ -635,8 +642,9 @@ impl EscrowContract {
     /// 
     /// # Arguments
     /// * `order_id` - Order identifier
-    /// * `authorized_address` - Address authorized to dispute (buyer or admin)
-    pub fn dispute_escrow(env: Env, order_id: u32, authorized_address: Address) {
+    /// * `dispute_reason` - Reason for dispute
+    /// * `authorized_address` - Address authorized to dispute (buyer or seller)
+    pub fn dispute_escrow(env: Env, order_id: u32, dispute_reason: String, authorized_address: Address) {
         authorized_address.require_auth();
 
         let escrow_opt = env
@@ -646,16 +654,15 @@ impl EscrowContract {
         if !(escrow_opt.is_some()) { env.panic_with_error(Error::EscrowNotFound); }
         let mut escrow: Escrow = escrow_opt.unwrap();
 
-        let config = Self::get_platform_config(&env);
-
-        // Allow buyer or admin to dispute
-        if !(escrow.buyer == authorized_address || authorized_address == config.admin) {
+        // Allow buyer or seller to dispute
+        if !(escrow.buyer == authorized_address || escrow.seller == authorized_address) {
             env.panic_with_error(Error::Unauthorized);
         }
 
-        if !(escrow.status == EscrowStatus::Pending) { env.panic_with_error(Error::InvalidEscrowState); }
+        if !(escrow.status == EscrowStatus::Active) { env.panic_with_error(Error::InvalidEscrowState); }
 
         escrow.status = EscrowStatus::Disputed;
+        escrow.dispute_reason = Some(dispute_reason.clone());
         env.storage()
             .persistent()
             .set(&(ESCROW, order_id), &escrow);
@@ -664,6 +671,7 @@ impl EscrowContract {
             (Symbol::new(&env, "escrow_disputed"), order_id as u64),
             EscrowDisputedEvent {
                 escrow_id: order_id as u64,
+                dispute_reason,
             },
         );
     }

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -42,7 +42,7 @@ fn test_create_escrow_success() {
     assert_eq!(escrow.buyer, buyer);
     assert_eq!(escrow.seller, seller);
     assert_eq!(escrow.amount, amount);
-    assert_eq!(escrow.status, EscrowStatus::Pending);
+    assert_eq!(escrow.status, EscrowStatus::Active);
     assert_eq!(escrow.release_window, window);
     
     let stored_escrow = client.get_escrow(&order_id);
@@ -197,10 +197,11 @@ fn test_dispute_escrow_success() {
     token_admin.mint(&buyer, &1000);
     client.create_escrow(&buyer, &seller, &token_id, &500, &1, &None);
     
-    client.dispute_escrow(&1, &buyer);
+    client.dispute_escrow(&1, &String::from("Item damaged"), &buyer);
     
     let escrow = client.get_escrow(&1);
     assert_eq!(escrow.status, EscrowStatus::Disputed);
+    assert_eq!(escrow.dispute_reason, Some(String::from("Item damaged")));
 
     // Verify event
     let events = env.events().all();
@@ -211,6 +212,55 @@ fn test_dispute_escrow_success() {
 }
 
 #[test]
+fn test_dispute_escrow_by_seller() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, token_admin, _) = setup_test(&env);
+
+    token_admin.mint(&buyer, &1000);
+    client.create_escrow(&buyer, &seller, &token_id, &500, &1, &None);
+
+    client.dispute_escrow(&1, &String::from("Payment not received"), &seller);
+
+    let escrow = client.get_escrow(&1);
+    assert_eq!(escrow.status, EscrowStatus::Disputed);
+    assert_eq!(escrow.dispute_reason, Some(String::from("Payment not received")));
+}
+
+#[test]
+fn test_dispute_escrow_unauthorized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, token_admin, _) = setup_test(&env);
+
+    token_admin.mint(&buyer, &1000);
+    client.create_escrow(&buyer, &seller, &token_id, &500, &1, &None);
+
+    let unauthorized = Address::generate(&env);
+    let result = std::panic::catch_unwind(|| {
+        client.dispute_escrow(&1, &String::from("Invalid reason"), &unauthorized);
+    });
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_disputed_prevents_release_and_refund() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, token_admin, _) = setup_test(&env);
+
+    token_admin.mint(&buyer, &1000);
+    client.create_escrow(&buyer, &seller, &token_id, &500, &1, &None);
+    client.dispute_escrow(&1, &String::from("Damaged item"), &buyer);
+
+    let release_err = std::panic::catch_unwind(|| { client.release_funds(&1); });
+    assert!(release_err.is_err());
+
+    let refund_err = std::panic::catch_unwind(|| { client.refund(&1, &buyer); });
+    assert!(refund_err.is_err());
+}
+
+#[test]
 fn test_resolve_dispute_release_to_seller() {
     let env = Env::default();
     env.mock_all_auths();
@@ -218,7 +268,7 @@ fn test_resolve_dispute_release_to_seller() {
 
     token_admin.mint(&buyer, &1000);
     client.create_escrow(&buyer, &seller, &token_id, &500, &1, &None);
-    client.dispute_escrow(&1, &buyer);
+    client.dispute_escrow(&1, &String::from("Non-delivery"), &buyer);
 
     // Arbitrator is setup in setup_test as a random Address and mock_all_auths bypasses auth
     client.resolve_dispute(&1, &Resolution::ReleaseToSeller);
@@ -242,7 +292,7 @@ fn test_resolve_dispute_refund_to_buyer() {
 
     token_admin.mint(&buyer, &1000);
     client.create_escrow(&buyer, &seller, &token_id, &500, &1, &None);
-    client.dispute_escrow(&1, &buyer);
+    client.dispute_escrow(&1, &String::from("Late shipping"), &buyer);
 
     client.resolve_dispute(&1, &Resolution::RefundToBuyer);
 


### PR DESCRIPTION


##  PR Description

### Title
`feat: implement disputed escrow flow with reason, block release/refund in dispute`

### Summary
Adds missing dispute lifecycle support in craft-nexus-contract, closing issue #57:

- `EscrowStatus` now includes explicit `Active` state.
- `Escrow` now holds `dispute_reason: Option<String>`.
- `EscrowDisputedEvent` includes dispute reason.
- `create_escrow` starts in `Active` and `dispute_reason = None`.
- `dispute_escrow(env, order_id, dispute_reason, caller)`:
  - requires caller auth
  - allowed only for buyer or seller
  - requires status `Active`
  - sets status `Disputed`
  - sets `dispute_reason`
  - emits `escrow_disputed` event with reason
- prevents `release_funds`, `auto_release`, `refund` when status is not `Active` (so Disputed path blocks).

### Testing
New/updated tests:
- `test_create_escrow_success` checks `Active` status
- `test_dispute_escrow_success` checks reason persistence + event
- `test_dispute_escrow_by_seller`
- `test_dispute_escrow_unauthorized`
- `test_disputed_prevents_release_and_refund`
- existing resolution tests continue to work with dispute lifecycle.
Closes : #57 