### PR TITLE
feat: Add validate_batch_creation for DevEx #119

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -1812,6 +1812,30 @@ impl EscrowContract {
         Ok(params.order_id as u64)
     }
 
+    /// DevEx: Dry-Run Batch Validation
+    /// Validates a batch of escrow creations without modifying state.
+    /// Returns a map of index -> Error for any escrow that fails validation.
+    pub fn validate_batch_creation(
+        env: Env,
+        escrows: soroban_sdk::Vec<EscrowCreateParams>,
+    ) -> Map<u32, Error> {
+        let mut errors: Map<u32, Error> = Map::new(&env);
+
+        if escrows.len() > MAX_BATCH_SIZE as u32 {
+            env.panic_with_error(Error::BatchOperationFailed);
+        }
+
+        for i in 0..escrows.len() {
+            if let Some(params) = escrows.get(i) {
+                if let Err(e) = Self::validate_escrow_params(&env, &params) {
+                    errors.set(i, e);
+                }
+            }
+        }
+
+        errors
+    }
+
     /// Create multiple escrows in a batch operation (Issue #111: Optimized)
     ///
     /// Validates all escrows first before processing any to ensure atomic behavior.

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -2111,3 +2111,85 @@ fn test_create_batch_escrow_with_metadata() {
         assert_eq!(metadata.metadata_hash, Some(metadata_hash_bytes.clone()));
     }
 }
+
+// ============================================================
+// DevEx #119 – Dry-Run Batch Validation
+// ============================================================
+
+#[test]
+fn test_validate_batch_creation() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, _, _, _) = setup_test(&env, true);
+
+    let invalid_amount = EscrowCreateParams {
+        buyer: buyer.clone(),
+        seller: seller.clone(),
+        token: token_id.clone(),
+        amount: 0,
+        order_id: 1,
+        release_window: Some(3600),
+        ipfs_hash: None,
+        metadata_hash: None,
+    };
+
+    let invalid_parties = EscrowCreateParams {
+        buyer: buyer.clone(),
+        seller: buyer.clone(),
+        token: token_id.clone(),
+        amount: 1000,
+        order_id: 2,
+        release_window: Some(3600),
+        ipfs_hash: None,
+        metadata_hash: None,
+    };
+
+    let valid_param = EscrowCreateParams {
+        buyer: buyer.clone(),
+        seller: seller.clone(),
+        token: token_id.clone(),
+        amount: 1000,
+        order_id: 3,
+        release_window: Some(3600),
+        ipfs_hash: None,
+        metadata_hash: None,
+    };
+
+    let mut batch_params = soroban_sdk::Vec::new(&env);
+    batch_params.push_back(invalid_amount);
+    batch_params.push_back(invalid_parties);
+    batch_params.push_back(valid_param);
+
+    let errors = client.validate_batch_creation(&batch_params);
+
+    assert_eq!(errors.len(), 2);
+    assert_eq!(errors.get(0).unwrap(), Error::AmountBelowMinimum);
+    assert_eq!(errors.get(1).unwrap(), Error::SameBuyerSeller);
+    assert!(errors.get(2).is_none());
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #14)")]
+fn test_validate_batch_creation_exceeds_limit() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, _, _, _) = setup_test(&env, true);
+
+    let valid_param = EscrowCreateParams {
+        buyer: buyer.clone(),
+        seller: seller.clone(),
+        token: token_id.clone(),
+        amount: 1000,
+        order_id: 1,
+        release_window: Some(3600),
+        ipfs_hash: None,
+        metadata_hash: None,
+    };
+
+    let mut batch_params = soroban_sdk::Vec::new(&env);
+    for _ in 0..101 { // MAX_BATCH_SIZE is 100
+        batch_params.push_back(valid_param.clone());
+    }
+
+    client.validate_batch_creation(&batch_params);
+}


### PR DESCRIPTION
This PR addresses DevEx issue #119 by adding the validate_batch_creation function to the EscrowContract, enabling frontends to perform comprehensive dry-runs of batch escrow creations before submitting them on-chain.

Key Changes:

Read-Only Validation: Performs identically strict checks mapped from validate_escrow_params dynamically.
Detailed Error Reporting: Returns a dictionary/map of Map<u32, Error> correlating the specific array index to its corresponding validation error, instead of a global revert.
Protected Batch Limit: Fails cleanly with Error::BatchOperationFailed if an attempt exceeds the platform's MAX_BATCH_SIZE limits.
Included full unit test verification within src/test.rs accounting for both singular edge cases and complete payload validations.
Closes #119

