### PR TITLE
[SECURITY] Fix Unrestricted WASM Upgrade Execution

### DIFF
--- a/craft-nexus-contract/src/enhanced_features_test.rs
+++ b/craft-nexus-contract/src/enhanced_features_test.rs
@@ -1,14 +1,16 @@
-#![cfg(test)]
+
 extern crate alloc;
 
 use super::*;
+use crate::onboarding::{OnboardingContract, OnboardingContractClient, ProfileStatus, UserRole};
 use soroban_sdk::{
-    testutils::{Address as _, Events, Ledger},
-    token, vec, Address, Bytes, BytesN, Env, IntoVal, String, Symbol, TryIntoVal,
+    testutils::{Address as _, Ledger},
+    token, Address, Env, String,
 };
-use crate::onboarding::{OnboardingContract, OnboardingContractClient, UserRole, ProfileStatus};
 
-fn setup_enhanced_test(env: &Env) -> (
+fn setup_enhanced_test(
+    env: &Env,
+) -> (
     EscrowContractClient<'static>,
     OnboardingContractClient<'static>,
     Address,
@@ -19,38 +21,42 @@ fn setup_enhanced_test(env: &Env) -> (
     Address,
 ) {
     env.mock_all_auths();
-    
+
     // Register Onboarding Contract
     let onboarding_id = env.register_contract(None, OnboardingContract);
     let onboarding_client = OnboardingContractClient::new(env, &onboarding_id);
-    
+
     // Register Escrow Contract
     let escrow_id = env.register_contract(None, EscrowContract);
     let escrow_client = EscrowContractClient::new(env, &escrow_id);
-    
+
     let admin = Address::generate(env);
     let platform_wallet = Address::generate(env);
     let arbitrator = Address::generate(env);
-    
+
     // Initialize Onboarding
     onboarding_client.initialize(&admin);
     onboarding_client.set_escrow_contract(&escrow_id);
-    
+
     // Initialize Escrow
     escrow_client.initialize(&platform_wallet, &admin, &arbitrator, &500);
     escrow_client.set_onboarding_contract(&onboarding_id);
-    
+
     let buyer = Address::generate(env);
     let artisan = Address::generate(env);
-    
+
     let token_admin = Address::generate(env);
     let token_contract = env.register_stellar_asset_contract_v2(token_admin.clone());
     let token_admin_client = token::StellarAssetClient::new(env, &token_contract.address());
-    
+
     // Onboard users
     onboarding_client.onboard_user(&buyer, &String::from_str(env, "buyer"), &UserRole::Buyer);
-    onboarding_client.onboard_user(&artisan, &String::from_str(env, "artisan"), &UserRole::Artisan);
-    
+    onboarding_client.onboard_user(
+        &artisan,
+        &String::from_str(env, "artisan"),
+        &UserRole::Artisan,
+    );
+
     (
         escrow_client,
         onboarding_client,
@@ -66,70 +72,73 @@ fn setup_enhanced_test(env: &Env) -> (
 #[test]
 fn test_recurring_escrow_lifecycle() {
     let env = Env::default();
-    let (escrow, _, buyer, artisan, token_id, token_admin, platform_wallet, _) = setup_enhanced_test(&env);
-    
+    let (escrow, _, buyer, artisan, token_id, token_admin, platform_wallet, _) =
+        setup_enhanced_test(&env);
+
     let total_amount: i128 = 1000;
     token_admin.mint(&buyer, &total_amount);
-    
+
     // 1. Create Recurring Escrow (2 cycles, frequency 3600)
-    let rec_escrow = escrow.create_recurring_escrow(&buyer, &artisan, &token_id, &total_amount, &3600, &2);
+    let rec_escrow =
+        escrow.create_recurring_escrow(&buyer, &artisan, &token_id, &total_amount, &3600, &2);
     assert_eq!(rec_escrow.total_amount, total_amount);
     assert!(rec_escrow.is_active);
-    assert_eq!(escrow.has_active_escrows(&buyer), true);
-    assert_eq!(escrow.has_active_escrows(&artisan), true);
-    
+    assert!(escrow.has_active_escrows(&buyer));
+    assert!(escrow.has_active_escrows(&artisan));
+
     // 2. Release 1st Cycle (after frequency)
     env.ledger().with_mut(|li| li.timestamp = 3601);
     escrow.release_next_cycle(&rec_escrow.id);
-    
+
     let token_client = token::Client::new(&env, &token_id);
     // Cycle 1: 500. Fee 5% = 25. Artisan gets 475.
     assert_eq!(token_client.balance(&artisan), 475);
     assert_eq!(token_client.balance(&platform_wallet), 25);
-    
+
     let updated = escrow.get_recurring_escrow(&rec_escrow.id);
     assert_eq!(updated.current_cycle, 1);
     assert_eq!(updated.released_amount, 500);
     assert!(updated.is_active);
-    
+
     // 3. Release 2nd Cycle
     env.ledger().with_mut(|li| li.timestamp = 7202);
     escrow.release_next_cycle(&rec_escrow.id);
-    
+
     assert_eq!(token_client.balance(&artisan), 950);
     assert_eq!(token_client.balance(&platform_wallet), 50);
-    
+
     let final_escrow = escrow.get_recurring_escrow(&rec_escrow.id);
-    assert_eq!(final_escrow.is_active, false);
-    assert_eq!(escrow.has_active_escrows(&buyer), false);
-    assert_eq!(escrow.has_active_escrows(&artisan), false);
+    assert!(!final_escrow.is_active);
+    assert!(!escrow.has_active_escrows(&buyer));
+    assert!(!escrow.has_active_escrows(&artisan));
 }
 
 #[test]
 fn test_cancel_recurring_escrow() {
     let env = Env::default();
     let (escrow, _, buyer, artisan, token_id, token_admin, _, _) = setup_enhanced_test(&env);
-    
+
     let total_amount: i128 = 1000;
     token_admin.mint(&buyer, &total_amount);
-    
-    let rec_escrow = escrow.create_recurring_escrow(&buyer, &artisan, &token_id, &total_amount, &3600, &2);
-    
+
+    let rec_escrow =
+        escrow.create_recurring_escrow(&buyer, &artisan, &token_id, &total_amount, &3600, &2);
+
     // Cancel immediately
     escrow.cancel_recurring_escrow(&rec_escrow.id);
-    
+
     let token_client = token::Client::new(&env, &token_id);
     assert_eq!(token_client.balance(&buyer), 1000);
     assert_eq!(token_client.balance(&escrow.address), 0);
-    
-    assert_eq!(escrow.has_active_escrows(&buyer), false);
+
+    assert!(!escrow.has_active_escrows(&buyer));
 }
 
 #[test]
 fn test_profile_deactivation_success() {
     let env = Env::default();
     let (escrow, onboarding, buyer, _, _, _, _, _) = setup_enhanced_test(&env);
-    
+
     // No active escrows, should succeed
     onboarding.deactivate_profile(&buyer);
     let profile = onboarding.get_user(&buyer);
@@ -141,11 +150,12 @@ fn test_profile_deactivation_success() {
 #[should_panic]
 fn test_profile_deactivation_fails_with_active_traditional_escrow() {
     let env = Env::default();
-    let (escrow, onboarding, buyer, artisan, token_id, token_admin, _, _) = setup_enhanced_test(&env);
-    
+    let (escrow, onboarding, buyer, artisan, token_id, token_admin, _, _) =
+        setup_enhanced_test(&env);
+
     token_admin.mint(&buyer, &1000);
     escrow.create_escrow(&buyer, &artisan, &token_id, &500, &1, &None);
-    
+
     onboarding.deactivate_profile(&buyer);
 }
 
@@ -153,11 +163,12 @@ fn test_profile_deactivation_fails_with_active_traditional_escrow() {
 #[should_panic]
 fn test_profile_deactivation_fails_with_active_recurring_escrow() {
     let env = Env::default();
-    let (escrow, onboarding, buyer, artisan, token_id, token_admin, _, _) = setup_enhanced_test(&env);
-    
+    let (escrow, onboarding, buyer, artisan, token_id, token_admin, _, _) =
+        setup_enhanced_test(&env);
+
     token_admin.mint(&buyer, &1000);
     escrow.create_recurring_escrow(&buyer, &artisan, &token_id, &1000, &3600, &2);
-    
+
     onboarding.deactivate_profile(&buyer);
 }
 
@@ -166,6 +177,6 @@ fn test_profile_deactivation_fails_with_active_recurring_escrow() {
 fn test_admin_deactivation_fails() {
     let env = Env::default();
     let (_, onboarding, _, _, _, _, _, admin) = setup_enhanced_test(&env);
-    
+
     onboarding.deactivate_profile(&admin);
 }

--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -5,9 +5,9 @@ use soroban_sdk::{
     BytesN, Env, Map, String, Symbol, TryFromVal, Val, Vec,
 };
 
-mod test;
 #[cfg(test)]
 mod enhanced_features_test;
+mod test;
 // Onboarding is a separate logical contract; only one `#[contract]` may be linked per WASM
 // artifact. Keep it in this crate for host tests (`cargo test`) but omit from guest builds.
 #[cfg(not(target_family = "wasm"))]
@@ -346,8 +346,6 @@ pub struct ArtisanFeeTierUpdatedEvent {
     pub fee_bps: u32,
 }
 
-
-
 #[contracttype]
 #[derive(Clone, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "testutils"), derive(Debug))]
@@ -428,7 +426,13 @@ pub struct PartialRefundProposal {
 #[soroban_sdk::contractclient(name = "OnboardingClient")]
 pub trait OnboardingInterface {
     fn update_reputation(env: Env, address: Address, successful_delta: u32, disputed_delta: u32);
-    fn update_user_metrics(env: Env, address: Address, escrow_count_delta: u32, volume_delta: i128, token_address: Address);
+    fn update_user_metrics(
+        env: Env,
+        address: Address,
+        escrow_count_delta: u32,
+        volume_delta: i128,
+        token_address: Address,
+    );
 }
 #[contract]
 pub struct EscrowContract;
@@ -478,7 +482,12 @@ impl EscrowContract {
             .publish((Symbol::new(env, "escrow"), event.escrow_id), event);
     }
 
-    fn emit_config_updated(env: &Env, field_name: &str, old_value: ConfigValue, new_value: ConfigValue) {
+    fn emit_config_updated(
+        env: &Env,
+        field_name: &str,
+        old_value: ConfigValue,
+        new_value: ConfigValue,
+    ) {
         env.events().publish(
             (
                 Symbol::new(env, "config_updated"),
@@ -748,10 +757,7 @@ impl EscrowContract {
     /// Completes the two-step transfer process (#95).
     pub fn claim_admin(env: Env) {
         let mut config = Self::get_platform_config_internal(&env);
-        let pending = config
-            .pending_admin
-            .as_ref()
-            .expect("");
+        let pending = config.pending_admin.as_ref().expect("");
         pending.require_auth();
 
         config.admin = pending.clone();
@@ -759,7 +765,6 @@ impl EscrowContract {
 
         env.storage().persistent().set(&PLATFORM_FEE, &config);
         Self::extend_persistent(&env, &PLATFORM_FEE);
-
     }
     /// Create a new escrow for an order
     ///
@@ -890,11 +895,7 @@ impl EscrowContract {
         Self::extend_persistent(&env, &ids_key);
 
         let count_key = DataKey::EscrowCount;
-        let count: u32 = env
-            .storage()
-            .persistent()
-            .get(&count_key)
-            .unwrap_or(0u32);
+        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0u32);
         env.storage().persistent().set(&count_key, &(count + 1));
         Self::extend_persistent(&env, &count_key);
 
@@ -928,15 +929,18 @@ impl EscrowContract {
         let client = token::Client::new(&env, &token);
         client.transfer(&buyer, &env.current_contract_address(), &amount);
 
-        Self::emit_escrow_event(&env, EscrowEvent {
-            escrow_id: order_id as u64,
-            action: EscrowAction::Created,
-            buyer: buyer.clone(),
-            seller: seller.clone(),
-            amount,
-            token: token.clone(),
-            timestamp: env.ledger().timestamp(),
-        });
+        Self::emit_escrow_event(
+            &env,
+            EscrowEvent {
+                escrow_id: order_id as u64,
+                action: EscrowAction::Created,
+                buyer: buyer.clone(),
+                seller: seller.clone(),
+                amount,
+                token: token.clone(),
+                timestamp: env.ledger().timestamp(),
+            },
+        );
 
         Self::exit_reentry_guard(&env);
         escrow
@@ -1014,11 +1018,7 @@ impl EscrowContract {
 
     fn get_stored_escrow(env: &Env, order_id: u32) -> Escrow {
         let key = (ESCROW, order_id);
-        let stored: Val = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .expect("");
+        let stored: Val = env.storage().persistent().get(&key).expect("");
         let map = Map::<Symbol, Val>::try_from_val(env, &stored).expect("");
         let version_key = Symbol::new(env, "version");
 
@@ -1099,13 +1099,22 @@ impl EscrowContract {
         Self::add_fee_token_to_index(env, token);
     }
 
-    fn transfer_platform_fee(env: &Env, token: &Address, platform_wallet: &Address, fee_amount: i128) {
+    fn transfer_platform_fee(
+        env: &Env,
+        token: &Address,
+        platform_wallet: &Address,
+        fee_amount: i128,
+    ) {
         if fee_amount <= 0 {
             return;
         }
 
         let token_client = token::Client::new(env, token);
-        token_client.transfer(&env.current_contract_address(), platform_wallet, &fee_amount);
+        token_client.transfer(
+            &env.current_contract_address(),
+            platform_wallet,
+            &fee_amount,
+        );
         Self::record_total_fees(env, token, fee_amount);
     }
 
@@ -1361,16 +1370,19 @@ impl EscrowContract {
     }
 
     /// Upgrade the contract's WASM code after the grace period has elapsed.
-    /// Can be called by anyone once the proposal is ready (#95).
+    /// Only the admin can execute the final upgrade once the proposal is ready (#137).
     pub fn update_wasm(env: Env) -> Result<(), Error> {
+        let admin = Self::get_admin(&env)?;
+        admin.require_auth();
+
         let proposal: WasmUpgradeProposal = env
             .storage()
             .persistent()
             .get(&DataKey::WasmUpgradeProposal)
-            .expect("");
+            .ok_or(Error::NoUpgradeProposed)?;
 
         if env.ledger().timestamp() < proposal.upgrade_at {
-            env.panic_with_error(crate::Error::UpgradeCooldownActive);
+            return Err(Error::UpgradeCooldownActive);
         }
 
         env.deployer()
@@ -1701,13 +1713,23 @@ impl EscrowContract {
                     // Seller wins dispute: successful for seller, disputed for buyer
                     client.update_reputation(&escrow.seller, &1u32, &0u32);
                     client.update_reputation(&escrow.buyer, &0u32, &1u32);
-                    client.update_user_metrics(&escrow.seller, &1u32, &escrow.amount, &escrow.token);
+                    client.update_user_metrics(
+                        &escrow.seller,
+                        &1u32,
+                        &escrow.amount,
+                        &escrow.token,
+                    );
                 }
                 Resolution::RefundToBuyer => {
                     // Buyer wins dispute: successful for buyer, disputed for seller
                     client.update_reputation(&escrow.buyer, &1u32, &0u32);
                     client.update_reputation(&escrow.seller, &0u32, &1u32);
-                    client.update_user_metrics(&escrow.seller, &1u32, &escrow.amount, &escrow.token);
+                    client.update_user_metrics(
+                        &escrow.seller,
+                        &1u32,
+                        &escrow.amount,
+                        &escrow.token,
+                    );
                 }
             }
         }
@@ -1787,7 +1809,7 @@ impl EscrowContract {
         let previous = config
             .moderator
             .clone()
-            .map(|address| ConfigValue::Address(address))
+            .map(ConfigValue::Address)
             .unwrap_or_else(|| ConfigValue::String(String::from_str(&env, "unset")));
         config.moderator = Some(moderator.clone());
         env.storage().persistent().set(&PLATFORM_FEE, &config);
@@ -1956,8 +1978,8 @@ impl EscrowContract {
         Self::extend_persistent(env, &(ESCROW, params.order_id));
 
         // Track active escrows (batch)
-        Self::update_active_obligations(&env, &params.buyer, 1);
-        Self::update_active_obligations(&env, &params.seller, 1);
+        Self::update_active_obligations(env, &params.buyer, 1);
+        Self::update_active_obligations(env, &params.seller, 1);
 
         // Transfer funds from buyer to contract
         let client = token::Client::new(env, &params.token);
@@ -1967,15 +1989,18 @@ impl EscrowContract {
             &params.amount,
         );
 
-        Self::emit_escrow_event(env, EscrowEvent {
-            escrow_id: params.order_id as u64,
-            action: EscrowAction::Created,
-            buyer: params.buyer.clone(),
-            seller: params.seller.clone(),
-            amount: params.amount,
-            token: params.token.clone(),
-            timestamp: env.ledger().timestamp(),
-        });
+        Self::emit_escrow_event(
+            env,
+            EscrowEvent {
+                escrow_id: params.order_id as u64,
+                action: EscrowAction::Created,
+                buyer: params.buyer.clone(),
+                seller: params.seller.clone(),
+                amount: params.amount,
+                token: params.token.clone(),
+                timestamp: env.ledger().timestamp(),
+            },
+        );
 
         Ok(params.order_id as u64)
     }
@@ -1989,7 +2014,7 @@ impl EscrowContract {
     ) -> Map<u32, Error> {
         let mut errors: Map<u32, Error> = Map::new(&env);
 
-        if escrows.len() > MAX_BATCH_SIZE as u32 {
+        if escrows.len() > MAX_BATCH_SIZE {
             env.panic_with_error(crate::Error::BatchLimitExceeded);
         }
 
@@ -2024,29 +2049,27 @@ impl EscrowContract {
     /// - Any validation error from individual escrows
     pub fn create_batch_escrow(
         env: Env,
-        batch_id: u64,
+        _batch_id: u64,
         escrows: soroban_sdk::Vec<EscrowCreateParams>,
     ) -> Result<soroban_sdk::Vec<u64>, Error> {
         Self::enter_reentry_guard(&env);
         Self::check_not_paused(&env);
 
         // Issue #111: Enforce batch size limit
-        if escrows.len() > MAX_BATCH_SIZE as u32 {
+        if escrows.len() > MAX_BATCH_SIZE {
             return Err(Error::BatchLimitExceeded);
         }
 
         let mut results = soroban_sdk::Vec::new(&env);
 
         // Early exit for empty batch
-        if escrows.len() == 0 {
+        if escrows.is_empty() {
             Self::exit_reentry_guard(&env);
             return Ok(results);
         }
 
         // Issue #111: Single authorization check - require auth from first buyer only
-        let first_params = escrows
-            .get(0)
-            .expect("");
+        let first_params = escrows.get(0).expect("");
         first_params.buyer.require_auth();
 
         // Issue #111: Validate all first (single pass)
@@ -2156,7 +2179,7 @@ impl EscrowContract {
         }
 
         // Consolidate global index updates for the entire batch
-        if results.len() > 0 {
+        if !results.is_empty() {
             let ids_key = DataKey::AllEscrowIds;
             let mut all_ids: soroban_sdk::Vec<u32> = env
                 .storage()
@@ -2172,11 +2195,7 @@ impl EscrowContract {
             Self::extend_persistent(&env, &ids_key);
 
             let count_key = DataKey::EscrowCount;
-            let count: u32 = env
-                .storage()
-                .persistent()
-                .get(&count_key)
-                .unwrap_or(0u32);
+            let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0u32);
             env.storage()
                 .persistent()
                 .set(&count_key, &(count + results.len()));
@@ -2197,7 +2216,7 @@ impl EscrowContract {
     /// * `authorized_address` - Address releasing the funds (buyer)
     pub fn release_batch_funds(
         env: Env,
-        batch_id: u64,
+        _batch_id: u64,
         order_ids: soroban_sdk::Vec<u32>,
         authorized_address: Address,
     ) -> Result<soroban_sdk::Vec<u64>, Error> {
@@ -2309,7 +2328,8 @@ impl EscrowContract {
 
     /// Admin pauses or unpauses the contract.
     pub fn set_paused(env: Env, paused: bool) {
-        let admin = Self::get_admin(&env).unwrap_or_else(|_| env.panic_with_error(crate::Error::Unauthorized));
+        let admin = Self::get_admin(&env)
+            .unwrap_or_else(|_| env.panic_with_error(crate::Error::Unauthorized));
         admin.require_auth();
 
         let mut config = Self::get_platform_config_internal(&env);
@@ -2328,7 +2348,8 @@ impl EscrowContract {
 
     /// Admin assigns a custom fee tier (in basis points) for an artisan.
     pub fn set_artisan_fee_tier(env: Env, artisan: Address, fee_bps: u32) {
-        let admin = Self::get_admin(&env).unwrap_or_else(|_| env.panic_with_error(crate::Error::Unauthorized));
+        let admin = Self::get_admin(&env)
+            .unwrap_or_else(|_| env.panic_with_error(crate::Error::Unauthorized));
         admin.require_auth();
 
         if fee_bps > MAX_PLATFORM_FEE_BPS {
@@ -2359,7 +2380,8 @@ impl EscrowContract {
 
     /// Admin sets the referral reward percentage (basis points of the platform fee).
     pub fn set_referral_reward_bps(env: Env, bps: u32) {
-        let admin = Self::get_admin(&env).unwrap_or_else(|_| env.panic_with_error(crate::Error::Unauthorized));
+        let admin = Self::get_admin(&env)
+            .unwrap_or_else(|_| env.panic_with_error(crate::Error::Unauthorized));
         admin.require_auth();
         if bps > 5000 {
             env.panic_with_error(crate::Error::InvalidFee);
@@ -2874,7 +2896,6 @@ impl EscrowContract {
             .unwrap_or(0);
         count > 0
     }
-
 
     /// Create a new recurring escrow for recurring payments/subscriptions.
     pub fn create_recurring_escrow(

--- a/craft-nexus-contract/src/onboarding.rs
+++ b/craft-nexus-contract/src/onboarding.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, token, Address, Env, Map,
-    String, Symbol, TryFromVal, Val, Vec,
+    contract, contracterror, contractimpl, contracttype, token, Address, Env, Map, String, Symbol,
+    TryFromVal, Val, Vec,
 };
 
 /// Standard TTL threshold for persistent storage (approx 14 hours at 5s ledger)
@@ -192,7 +192,7 @@ fn normalize_username(env: &Env, username: &String) -> String {
     const MAX_OUTPUT_BYTES: usize = 256;
     let len = username.len() as usize;
     if len > MAX_INPUT_BYTES {
-        // Can't use env.panic_with_error here without Env. 
+        // Can't use env.panic_with_error here without Env.
         // But we can just use unwrap() on a None or something similar if we want to save space,
         // or just let it panic without a string.
         panic!();
@@ -543,14 +543,11 @@ impl OnboardingContract {
             .persistent()
             .get(&key)
             .unwrap_or_else(|| env.panic_with_error(Error::UserNotFound));
-        let map = Map::<Symbol, Val>::try_from_val(env, &stored)
-            .expect("");
+        let map = Map::<Symbol, Val>::try_from_val(env, &stored).expect("");
         let version_key = Symbol::new(env, "version");
 
         if map.contains_key(version_key) {
-            let profile =
-                UserProfile::try_from_val(env, &stored)
-                    .expect("");
+            let profile = UserProfile::try_from_val(env, &stored).expect("");
             if profile.version < CURRENT_USER_PROFILE_VERSION {
                 return Self::upgrade_user_profile(env, user, profile);
             }
@@ -919,8 +916,10 @@ impl OnboardingContract {
         Self::extend_persistent(&env, &DataKey::UserProfile(user.clone()));
 
         // Emit event
-        env.events()
-            .publish((Symbol::new(&env, "ProfileDeactivated"), user.clone()), user);
+        env.events().publish(
+            (Symbol::new(&env, "ProfileDeactivated"), user.clone()),
+            user,
+        );
     }
 
     /// Verify user (admin only)
@@ -1326,7 +1325,10 @@ impl OnboardingContract {
 
         for index in head..tail {
             let queue_index_key = DataKey::VerificationQueueIndex(index);
-            if let Some(user) = env.storage().persistent().get::<DataKey, Address>(&queue_index_key)
+            if let Some(user) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, Address>(&queue_index_key)
             {
                 if Self::is_verification_pending(&env, &user) {
                     queue.push_back(user);

--- a/craft-nexus-contract/src/onboarding_test.rs
+++ b/craft-nexus-contract/src/onboarding_test.rs
@@ -861,7 +861,11 @@ fn test_change_username_cooldown_active() {
     let (client, _) = setup_test(&env);
     let user = Address::generate(&env);
 
-    client.onboard_user(&user, &String::from_str(&env, "original_user"), &UserRole::Buyer);
+    client.onboard_user(
+        &user,
+        &String::from_str(&env, "original_user"),
+        &UserRole::Buyer,
+    );
     client.change_username(&user, &String::from_str(&env, "first_change"));
 
     // Immediate second change should be blocked by cooldown.
@@ -1018,7 +1022,11 @@ fn test_change_username_fee_requires_token_configuration() {
     let (client, _) = setup_test(&env);
     let user = Address::generate(&env);
 
-    client.onboard_user(&user, &String::from_str(&env, "needs_fee"), &UserRole::Buyer);
+    client.onboard_user(
+        &user,
+        &String::from_str(&env, "needs_fee"),
+        &UserRole::Buyer,
+    );
     client.set_username_change_fee(&1_000_000);
 
     client.change_username(&user, &String::from_str(&env, "still_needs_fee"));
@@ -1059,14 +1067,14 @@ fn test_change_username_preserves_other_fields() {
         &UserRole::Artisan,
     );
     assert_eq!(original.role, UserRole::Artisan);
-    assert_eq!(original.is_verified, false);
+    assert!(!original.is_verified);
 
     // Change username
     let updated = client.change_username(&user, &String::from_str(&env, "new_name"));
 
     // Verify other fields are preserved
     assert_eq!(updated.role, UserRole::Artisan);
-    assert_eq!(updated.is_verified, false);
+    assert!(!updated.is_verified);
     assert_eq!(updated.address, user);
     assert_eq!(updated.registered_at, original.registered_at);
 }
@@ -1083,13 +1091,13 @@ fn test_volume_normalization_across_decimals() {
     let token_admin = Address::generate(&env);
     let token_7 = env.register_stellar_asset_contract_v2(token_admin);
     client.update_user_metrics(&user, &1u32, &1_000_000_000i128, &token_7.address());
-    
+
     let metrics = client.get_user_metrics(&user);
     assert_eq!(metrics.total_volume, 1_000_000_000); // 100.0000000 USDC -> 100.0000000 normalized
 
     // 2. Test 6-decimal token (e.g., some USDC versions or USDT)
     // We can't easily change decimals of Stellar Asset Contract in tests (it's always 7),
-    // but we've verified the code logic. 
+    // but we've verified the code logic.
     // The code logic is:
     // let normalized_delta = if token_decimals < base_decimals {
     //     let diff = base_decimals - token_decimals;
@@ -1132,7 +1140,10 @@ fn test_update_portfolio_with_cidv1() {
     client.onboard_user(&user, &username, &UserRole::Artisan);
 
     // Update portfolio with valid CIDv1 (base32)
-    let portfolio_cid = String::from_str(&env, "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi");
+    let portfolio_cid = String::from_str(
+        &env,
+        "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+    );
     let updated = client.update_portfolio(&user, &Some(portfolio_cid.clone()));
 
     assert_eq!(updated.portfolio_cid, Some(portfolio_cid));
@@ -1279,7 +1290,7 @@ fn test_portfolio_preserves_other_fields() {
     // Onboard as artisan
     let original = client.onboard_user(&user, &username, &UserRole::Artisan);
     assert_eq!(original.role, UserRole::Artisan);
-    assert_eq!(original.is_verified, false);
+    assert!(!original.is_verified);
 
     // Update portfolio
     let portfolio_cid = String::from_str(&env, "QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG");
@@ -1287,7 +1298,7 @@ fn test_portfolio_preserves_other_fields() {
 
     // Verify other fields are preserved
     assert_eq!(updated.role, UserRole::Artisan);
-    assert_eq!(updated.is_verified, false);
+    assert!(!updated.is_verified);
     assert_eq!(updated.address, user);
     assert_eq!(updated.registered_at, original.registered_at);
 }

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -745,10 +745,7 @@ fn test_initialize_emits_config_events() {
         .try_into_val(&env)
         .unwrap();
 
-    assert_eq!(
-        fee_event.field_name,
-        Symbol::new(&env, "platform_fee_bps")
-    );
+    assert_eq!(fee_event.field_name, Symbol::new(&env, "platform_fee_bps"));
     assert_eq!(
         wallet_event.field_name,
         Symbol::new(&env, "platform_wallet")
@@ -1052,8 +1049,14 @@ fn test_integration_multiple_tokens_and_escrows() {
     let fee_b = token_b.balance(&platform_wallet);
     assert_eq!(fee_a, 500_000);
     assert_eq!(fee_b, 500_000);
-    assert_eq!(client.get_total_fees_for_token(&token_a_contract.address()), 500_000);
-    assert_eq!(client.get_total_fees_for_token(&token_b_contract.address()), 500_000);
+    assert_eq!(
+        client.get_total_fees_for_token(&token_a_contract.address()),
+        500_000
+    );
+    assert_eq!(
+        client.get_total_fees_for_token(&token_b_contract.address()),
+        500_000
+    );
     assert_eq!(client.get_total_fees_collected(), 1_000_000);
 }
 
@@ -2502,7 +2505,8 @@ fn test_validate_batch_creation_exceeds_limit() {
     };
 
     let mut batch_params = soroban_sdk::Vec::new(&env);
-    for _ in 0..101 { // MAX_BATCH_SIZE is 100
+    for _ in 0..101 {
+        // MAX_BATCH_SIZE is 100
         batch_params.push_back(valid_param.clone());
     }
 


### PR DESCRIPTION
Closes #137 

**Description:**
This PR addresses a security vulnerability (#137) where the final contract upgrade execution (`update_wasm`) was callable by any address after the grace period ended.

**Key Implementation Details:**
*   **Authorization Guard:** Added a mandatory `require_auth()` check for the platform administrator to ensure that even after the cooldown elapses, the final upgrade is an intentional administrative action.
*   **Refactored Error Model:** Replaced placeholders like `.expect("")` and `panic_with_error` with structured `Result` returns (e.g., `Error::NoUpgradeProposed`), improving consistency and production readiness.
*   **Performance:** All added checks remain $O(1)$ in time and space complexity, utilizing the pre-existing `get_admin` helper.
*   **Code Hygiene:** Applied `cargo fmt` and resolved secondary `clippy` warnings (unused variables) in the upgrade path.