### PR TITLE
Fix #136: Self-Acknowledged Auth Bug in Partial Refunds

### DIFF
--- a/craft-nexus-contract/src/enhanced_features_test.rs
+++ b/craft-nexus-contract/src/enhanced_features_test.rs
@@ -1,4 +1,3 @@
-
 extern crate alloc;
 
 use super::*;
@@ -38,9 +37,8 @@ fn setup_enhanced_test(
     onboarding_client.initialize(&admin);
     onboarding_client.set_escrow_contract(&escrow_id);
 
-    // Initialize Escrow
-    escrow_client.initialize(&platform_wallet, &admin, &arbitrator, &500);
-    escrow_client.set_onboarding_contract(&onboarding_id);
+    // Initialize Escrow with onboarding contract address
+    escrow_client.initialize(&platform_wallet, &admin, &arbitrator, &500, &onboarding_id);
 
     let buyer = Address::generate(env);
     let artisan = Address::generate(env);

--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -683,14 +683,11 @@ impl EscrowContract {
         admin: Address,
         arbitrator: Address,
         platform_fee_bps: u32,
+        onboarding_contract: Address,
     ) {
         admin.require_auth();
 
         // Validate fee is within bounds
-        if platform_fee_bps > MAX_PLATFORM_FEE_BPS {
-            env.panic_with_error(crate::Error::InvalidFee);
-        }
-
         if platform_fee_bps > MAX_PLATFORM_FEE_BPS {
             env.panic_with_error(crate::Error::InvalidFee);
         }
@@ -728,6 +725,12 @@ impl EscrowContract {
             .set(&DataKey::ContractVersion, &1u32);
         Self::extend_persistent(&env, &DataKey::ContractVersion);
 
+        // Set the onboarding contract address to enable reputation tracking
+        env.storage()
+            .persistent()
+            .set(&DataKey::OnboardingContractAddress, &onboarding_contract);
+        Self::extend_persistent(&env, &DataKey::OnboardingContractAddress);
+
         Self::emit_config_updated(
             &env,
             "platform_fee_bps",
@@ -739,6 +742,12 @@ impl EscrowContract {
             "platform_wallet",
             ConfigValue::String(String::from_str(&env, "unset")),
             ConfigValue::Address(platform_wallet),
+        );
+        Self::emit_config_updated(
+            &env,
+            "onboarding_contract",
+            ConfigValue::String(String::from_str(&env, "unset")),
+            ConfigValue::Address(onboarding_contract),
         );
     }
 
@@ -2638,10 +2647,16 @@ impl EscrowContract {
     ///
     /// Either the buyer or seller may submit a proposal. Only one proposal may be
     /// active at a time; a second call returns ProposalAlreadyExists.
+    ///
+    /// # Arguments
+    /// * `order_id` - Order identifier
+    /// * `refund_amount` - Amount to refund to the buyer
+    /// * `proposed_by` - Address of the party proposing the refund (must be buyer or seller)
     pub fn propose_partial_refund(
         env: Env,
         order_id: u32,
         refund_amount: i128,
+        proposed_by: Address,
     ) -> Result<(), Error> {
         let escrow_opt: Option<Escrow> = env.storage().persistent().get(&(ESCROW, order_id));
         if escrow_opt.is_none() {
@@ -2653,51 +2668,13 @@ impl EscrowContract {
             return Err(Error::InvalidEscrowState);
         }
 
-        // Determine caller: must be buyer or seller
-        // We try requiring auth from buyer first; if caller is seller, that auth will succeed.
-        // In Soroban the simplest approach is to pass the caller address explicitly, but
-        // per the spec we infer from context. We accept the address and require its auth.
-        // The caller must pass their own address so we know who proposed.
-        // Since the spec says "caller is buyer or seller", and Soroban auth model requires
-        // an explicit address, we check both and the one that matches must have authorised.
-        // We model this as: the function checks buyer auth OR seller auth.
-        // We can't call require_auth on an unknown caller; callers must self-identify.
-        // Per Soroban convention, we require the caller to pass their address.
-        // The spec doesn't list a `caller` param, so we determine from auth context using
-        // a conservative approach: require buyer auth first; if that fails the contract
-        // will panic. To allow either party, we instead require both to attempt and take
-        // the first success. Soroban doesn't support try-auth, so we expose the caller address.
-        // We'll match on escrow members and require auth from the matched address.
-        // Note: the real constraint is captured at the contract boundary by requiring auth
-        // from the proposed_by field populated after identification. We follow the pattern
-        // used elsewhere in the contract and require a `proposed_by` address parameter.
-        // However the spec says no extra param - so we accept both: try buyer, then seller.
-        // In Soroban the idiomatic way is to pass the caller. We will accept caller address.
-        // For strict spec compliance (no extra param), we require BOTH auths and let the
-        // caller decide which to provide. The call will succeed if either auth is available.
-        //
-        // Simplest correct implementation: add a `caller: Address` param would be ideal,
-        // but since the spec omits it, we require buyer auth (the most common proposer).
-        // Sellers wishing to propose must call with buyer auth too - which is wrong.
-        // Best no-extra-param approach: require auth from both and let Soroban short-circuit.
-        // This is safe because require_auth panics on failure, so we use a workaround:
-        // We store proposal with proposed_by = escrow.buyer as default and let either call.
-        // Final decision: require auth from buyer (standard) but allow seller by also
-        // attempting their auth. In practice the contract verifies whoever calls.
-        //
-        // IMPLEMENTATION: We use `proposed_by` derived from an internal caller-resolution
-        // pattern. Since we cannot enumerate "try auth", we expose the simplest valid
-        // implementation that is syntactically correct: the buyer proposes by default.
-        // The accept function checks the counterparty, so this is still logically sound.
-        //
-        // For production use a `caller: Address` parameter is recommended.
+        // Verify proposed_by is either the buyer or seller
+        if proposed_by != escrow.buyer && proposed_by != escrow.seller {
+            return Err(Error::Unauthorized);
+        }
 
-        // Require auth from either buyer or seller; Soroban requires explicit address
-        // We'll treat buyer as the default proposer; seller can propose by calling with
-        // their own auth if they are the seller. We resolve by requiring the caller
-        // to authorize themselves through the buyer/seller match.
-        escrow.buyer.require_auth();
-        let proposed_by = escrow.buyer.clone();
+        // Require auth from the proposing party
+        proposed_by.require_auth();
 
         if refund_amount <= 0 || refund_amount > escrow.amount {
             return Err(Error::InvalidRefundAmount);

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -35,6 +35,7 @@ fn setup_test(
     let token_admin_client = token::StellarAssetClient::new(env, &token_contract.address());
 
     let arbitrator = Address::generate(env);
+    let onboarding_contract = Address::generate(env);
 
     // Set a non-zero timestamp for event tests
     env.ledger().with_mut(|li| {
@@ -42,7 +43,13 @@ fn setup_test(
     });
 
     // Initialize contract with platform config
-    client.initialize(&platform_wallet, &admin, &arbitrator, &500);
+    client.initialize(
+        &platform_wallet,
+        &admin,
+        &arbitrator,
+        &500,
+        &onboarding_contract,
+    );
 
     // Set min amount to 0 for tests to pass with small amounts
     client.set_min_escrow_amount(&token_contract.address(), &0);
@@ -569,7 +576,14 @@ fn test_platform_fee_deduction_10_percent() {
     let arbitrator = Address::generate(&env);
 
     // Initialize with 10% fee
-    client.initialize(&platform_wallet, &admin, &arbitrator, &1000);
+    let onboarding_contract = Address::generate(&env);
+    client.initialize(
+        &platform_wallet,
+        &admin,
+        &arbitrator,
+        &1000,
+        &onboarding_contract,
+    );
 
     token_admin_client.mint(&buyer, &10_000_000);
     client.create_escrow(
@@ -635,7 +649,14 @@ fn test_update_platform_fee() {
     let arbitrator = Address::generate(&env);
 
     // Initialize with 5% fee
-    client.initialize(&platform_wallet, &admin, &arbitrator, &500);
+    let onboarding_contract = Address::generate(&env);
+    client.initialize(
+        &platform_wallet,
+        &admin,
+        &arbitrator,
+        &500,
+        &onboarding_contract,
+    );
 
     // Get initial fee
     assert_eq!(client.get_platform_fee(), 500);
@@ -692,7 +713,14 @@ fn test_update_platform_fee_too_high() {
     let arbitrator = Address::generate(&env);
 
     // Initialize with 5% fee
-    client.initialize(&platform_wallet, &admin, &arbitrator, &500);
+    let onboarding_contract = Address::generate(&env);
+    client.initialize(
+        &platform_wallet,
+        &admin,
+        &arbitrator,
+        &500,
+        &onboarding_contract,
+    );
 
     // Try to set fee above max (10%)
     client.update_platform_fee(&1500);
@@ -729,7 +757,14 @@ fn test_initialize_emits_config_events() {
     let platform_wallet = Address::generate(&env);
     let arbitrator = Address::generate(&env);
 
-    client.initialize(&platform_wallet, &admin, &arbitrator, &500);
+    let onboarding_contract = Address::generate(&env);
+    client.initialize(
+        &platform_wallet,
+        &admin,
+        &arbitrator,
+        &500,
+        &onboarding_contract,
+    );
 
     let events = env.events().all();
     let fee_event: ConfigUpdatedEvent = events
@@ -984,7 +1019,14 @@ fn test_fee_rounding_custom_bps_025_percent() {
     let arbitrator = Address::generate(&env);
 
     // 25 bps = 0.25%
-    client.initialize(&platform_wallet, &admin, &arbitrator, &25);
+    let onboarding_contract = Address::generate(&env);
+    client.initialize(
+        &platform_wallet,
+        &admin,
+        &arbitrator,
+        &25,
+        &onboarding_contract,
+    );
     assert_eq!(client.calculate_fee_for_amount(&1000), 2); // floor(2.5) => 2
     assert_eq!(client.calculate_fee_for_amount(&399), 0); // floor(0.9975) => 0
     assert_eq!(client.calculate_fee_for_amount(&400), 1); // floor(1.0) => 1
@@ -1373,7 +1415,14 @@ fn test_contract_address_admin_is_authorized() {
         li.timestamp = 1711368000;
     });
 
-    client.initialize(&platform_wallet, &admin_contract, &arbitrator, &500);
+    let onboarding_contract = Address::generate(&env);
+    client.initialize(
+        &platform_wallet,
+        &admin_contract,
+        &arbitrator,
+        &500,
+        &onboarding_contract,
+    );
     client.set_min_escrow_amount(&token_contract.address(), &0);
 
     let config = client.get_platform_config();

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -1045,7 +1045,14 @@ fn test_integration_multiple_tokens_and_escrows() {
     let admin = Address::generate(&env);
     let arbitrator = Address::generate(&env);
 
-    client.initialize(&platform_wallet, &admin, &arbitrator, &500);
+    let onboarding_contract = Address::generate(&env);
+    client.initialize(
+        &platform_wallet,
+        &admin,
+        &arbitrator,
+        &500,
+        &onboarding_contract,
+    );
 
     // Token A
     let token_a_admin = Address::generate(&env);


### PR DESCRIPTION
Fix #136: Self-Acknowledged Auth Bug in Partial Refunds
- Update propose_partial_refund to accept proposed_by parameter
- Require auth from the proposing party instead of always requiring buyer auth
- Verify proposed_by is either buyer or seller

Fix #146: Automated Reputation Fallback

- Add onboarding_contract parameter to initialize function
- Set onboarding contract address during initialization to prevent silent reputation loss
- Update all tests to pass the new parameter

Closes: #136
Closes: #146