### PR TITLE
Add metadata verification events and platform pause/unpause events

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -158,7 +158,8 @@ pub enum DataKey {
     PlatformConfig,
     /// Custom fee tier for an artisan (basis points)
     ArtisanFeeTier(Address),
-    /// Referral reward percentage in basis points
+    /// Deprecated referral reward percentage in basis points.
+    /// Retained only for storage compatibility; referral payout logic is not implemented.
     ReferralRewardBps,
     /// Staked token amount and asset for an artisan
     ArtisanStake(Address),
@@ -375,6 +376,31 @@ pub struct TokensUnstakedEvent {
 #[contracttype]
 #[derive(Clone, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "testutils"), derive(Debug))]
+pub struct MetadataVerifiedEvent {
+    pub order_id: u64,
+    pub verifier: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "testutils"), derive(Debug))]
+pub struct PlatformPausedEvent {
+    pub initiator: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "testutils"), derive(Debug))]
+pub struct PlatformUnpausedEvent {
+    pub initiator: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "testutils"), derive(Debug))]
 pub struct EscrowMetadata {
     pub ipfs_hash: Option<String>,
     pub metadata_hash: Option<Bytes>,
@@ -534,6 +560,46 @@ impl EscrowContract {
                 artisan.clone(),
             ),
             ArtisanFeeTierUpdatedEvent { artisan, fee_bps },
+        );
+    }
+
+    fn emit_metadata_verified(env: &Env, order_id: u32, verifier: Address) {
+        env.events().publish(
+            (
+                Symbol::new(env, "metadata_verified"),
+                (order_id as u64),
+            ),
+            MetadataVerifiedEvent {
+                order_id: order_id as u64,
+                verifier,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+    }
+
+    fn emit_platform_paused(env: &Env, initiator: Address) {
+        env.events().publish(
+            (
+                Symbol::new(env, "platform_paused"),
+                initiator.clone(),
+            ),
+            PlatformPausedEvent {
+                initiator,
+                timestamp: env.ledger().timestamp(),
+            },
+        );
+    }
+
+    fn emit_platform_unpaused(env: &Env, initiator: Address) {
+        env.events().publish(
+            (
+                Symbol::new(env, "platform_unpaused"),
+                initiator.clone(),
+            ),
+            PlatformUnpausedEvent {
+                initiator,
+                timestamp: env.ledger().timestamp(),
+            },
         );
     }
 
@@ -1611,6 +1677,36 @@ impl EscrowContract {
         computed_bytes == stored_hash
     }
 
+    /// Authorized verification that records successful metadata matching on-chain.
+    ///
+    /// Only the escrow buyer, seller, or admin may call this method. A successful verification
+    /// emits a permanent MetadataVerified event.
+    pub fn verify_metadata_reveal_recorded(
+        env: Env,
+        order_id: u32,
+        proof: MetadataRevealProof,
+        authorized_address: Address,
+    ) -> bool {
+        authorized_address.require_auth();
+
+        let escrow = Self::get_escrow(env.clone(), order_id);
+        let admin = Self::get_admin(&env)
+            .unwrap_or_else(|_| env.panic_with_error(crate::Error::Unauthorized));
+
+        let is_authorized = authorized_address == escrow.buyer
+            || authorized_address == escrow.seller
+            || authorized_address == admin;
+        if !is_authorized {
+            env.panic_with_error(crate::Error::Unauthorized);
+        }
+
+        let is_valid = Self::verify_metadata_reveal(env.clone(), order_id, proof);
+        if is_valid {
+            Self::emit_metadata_verified(&env, order_id, authorized_address);
+        }
+        is_valid
+    }
+
     /// Check if escrow can be auto-released
     ///
     /// # Arguments
@@ -2342,7 +2438,8 @@ impl EscrowContract {
         Ok(results)
     }
 
-    // ── Circuit Breaker (#96) ───────────────────────────────────────
+    // NOTE: referral payout support has been removed from the contract. The configuration key is
+    // retained only for storage compatibility during upgrades.
 
     /// Check that the contract is not paused. Panics with ContractPaused if it is.
     fn check_not_paused(env: &Env) {
@@ -2367,6 +2464,12 @@ impl EscrowContract {
         config.is_paused = paused;
         env.storage().persistent().set(&DataKey::PlatformConfig, &config);
         Self::extend_persistent(&env, &DataKey::PlatformConfig);
+
+        if paused {
+            Self::emit_platform_paused(&env, admin);
+        } else {
+            Self::emit_platform_unpaused(&env, admin);
+        }
     }
 
     /// View: check if contract is paused.

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -2280,6 +2280,95 @@ fn test_verify_metadata_reveal_success() {
     assert!(is_valid);
 }
 
+#[test]
+fn test_verify_metadata_reveal_authorized_emits_metadata_verified_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, token_admin, _, _) = setup_test(&env, true);
+
+    token_admin.mint(&buyer, &100_000_000);
+
+    let content = Bytes::from_slice(&env, b"test metadata content");
+    let content_hash = env.crypto().sha256(&content);
+    let content_hash_bytes: Bytes = content_hash.into();
+
+    client.create_escrow_with_metadata(
+        &buyer,
+        &seller,
+        &token_id,
+        &500,
+        &1,
+        &Some(3600),
+        &None,
+        &Some(content_hash_bytes.clone()),
+    );
+
+    let proof = MetadataRevealProof {
+        content: content.clone(),
+        secret: None,
+    };
+
+    let is_valid = client.verify_metadata_reveal_recorded(&1, &proof, &buyer);
+    assert!(is_valid);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    assert_eq!(
+        last_event.1,
+        vec![
+            &env,
+            Symbol::new(&env, "metadata_verified").into_val(&env),
+            (1u64).into_val(&env),
+        ]
+    );
+
+    let event: MetadataVerifiedEvent = last_event.2.try_into_val(&env).unwrap();
+    assert_eq!(event.order_id, 1);
+    assert_eq!(event.verifier, buyer);
+    assert_eq!(event.timestamp, 1711368000);
+}
+
+#[test]
+fn test_set_paused_emits_platform_status_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _, _, admin) = setup_test(&env, true);
+
+    client.set_paused(&true);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    assert_eq!(
+        last_event.1,
+        vec![
+            &env,
+            Symbol::new(&env, "platform_paused").into_val(&env),
+            admin.clone().into_val(&env),
+        ]
+    );
+
+    let paused_event: PlatformPausedEvent = last_event.2.try_into_val(&env).unwrap();
+    assert_eq!(paused_event.initiator, admin.clone());
+    assert_eq!(paused_event.timestamp, 1711368000);
+
+    client.set_paused(&false);
+
+    let events = env.events().all();
+    let last_event = events.last().unwrap();
+    assert_eq!(
+        last_event.1,
+        vec![
+            &env,
+            Symbol::new(&env, "platform_unpaused").into_val(&env),
+            admin.clone().into_val(&env),
+        ]
+    );
+
+    let unpaused_event: PlatformUnpausedEvent = last_event.2.try_into_val(&env).unwrap();
+    assert_eq!(unpaused_event.initiator, admin);
+    assert_eq!(unpaused_event.timestamp, 1711368000);
+}
+
 /// Test metadata reveal verification with invalid content (Issue #122)
 #[test]
 fn test_verify_metadata_reveal_invalid_content() {


### PR DESCRIPTION

Description:

Implemented an authorized metadata verification entrypoint that emits MetadataVerifiedEvent when a metadata reveal matches the stored hash.
Added PlatformPausedEvent and PlatformUnpausedEvent to [set_paused(...)](https://literate-tribble-9pgjrxp76jg3xr5x.github.dev/) for better platform monitoring.
Removed the orphaned referral reward payout support from active logic; the referral config key is retained only for storage compatibility.
Added contract tests covering the new event emissions.
Closes : #181
Closes : #184

Closes:  #190