### PR TITLE
Improve escrow retrieval and onboarding traceability UX

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -1307,6 +1307,7 @@ impl EscrowContract {
         buyer: Address,
         page: u32,
         limit: u32,
+        reverse: bool,
     ) -> Result<soroban_sdk::Vec<u64>, Error> {
         let mut result = soroban_sdk::Vec::new(&env);
 
@@ -1322,8 +1323,13 @@ impl EscrowContract {
 
             let end = (start + limit).min(total_count);
 
-            for i in start..end {
-                let index_key = DataKey::BuyerEscrowIndexed(buyer.clone(), i);
+            for position in start..end {
+                let storage_index = if reverse {
+                    total_count - 1 - position
+                } else {
+                    position
+                };
+                let index_key = DataKey::BuyerEscrowIndexed(buyer.clone(), storage_index);
                 if let Some(escrow_id) = env.storage().persistent().get::<_, u64>(&index_key) {
                     result.push_back(escrow_id);
                     env.storage().persistent().extend_ttl(&index_key, 1000, 518400);
@@ -1354,7 +1360,16 @@ impl EscrowContract {
         }
 
         let end = (start + limit).min(len);
-        Ok(escrow_ids.slice(start..end))
+        if reverse {
+            for position in start..end {
+                if let Some(escrow_id) = escrow_ids.get(len - 1 - position) {
+                    result.push_back(escrow_id);
+                }
+            }
+            Ok(result)
+        } else {
+            Ok(escrow_ids.slice(start..end))
+        }
     }
 
     /// Get escrows for a specific seller with pagination.
@@ -1364,6 +1379,7 @@ impl EscrowContract {
         seller: Address,
         page: u32,
         limit: u32,
+        reverse: bool,
     ) -> Result<soroban_sdk::Vec<u64>, Error> {
         let mut result = soroban_sdk::Vec::new(&env);
 
@@ -1379,8 +1395,13 @@ impl EscrowContract {
 
             let end = (start + limit).min(total_count);
 
-            for i in start..end {
-                let index_key = DataKey::SellerEscrowIndexed(seller.clone(), i);
+            for position in start..end {
+                let storage_index = if reverse {
+                    total_count - 1 - position
+                } else {
+                    position
+                };
+                let index_key = DataKey::SellerEscrowIndexed(seller.clone(), storage_index);
                 if let Some(escrow_id) = env.storage().persistent().get::<_, u64>(&index_key) {
                     result.push_back(escrow_id);
                     env.storage().persistent().extend_ttl(&index_key, 1000, 518400);
@@ -1411,7 +1432,16 @@ impl EscrowContract {
         }
 
         let end = (start + limit).min(len);
-        Ok(escrow_ids.slice(start..end))
+        if reverse {
+            for position in start..end {
+                if let Some(escrow_id) = escrow_ids.get(len - 1 - position) {
+                    result.push_back(escrow_id);
+                }
+            }
+            Ok(result)
+        } else {
+            Ok(escrow_ids.slice(start..end))
+        }
     }
 
     /// Get platform configuration

--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -146,7 +146,7 @@ const DEFAULT_MIN_RELEASE_WINDOW: u32 = 24 * 60 * 60;
 /// Maximum platform fee in basis points (10000 = 100%)
 const MAX_PLATFORM_FEE_BPS: u32 = 1000; // 10% max
 const MAX_TOTAL_RELEASE_WINDOW: u32 = 2592000; // 30 days
-const CURRENT_ESCROW_VERSION: u32 = 2;
+const CURRENT_ESCROW_VERSION: u32 = 3;
 /// Maximum number of escrows per batch operation (Issue #111)
 const MAX_BATCH_SIZE: u32 = 100;
 
@@ -290,6 +290,7 @@ pub enum Resolution {
 pub struct Escrow {
     pub version: u32,
     pub id: u64,
+    pub batch_id: Option<u64>,
     pub buyer: Address,
     pub seller: Address,
     pub token: Address,
@@ -307,6 +308,25 @@ pub struct Escrow {
 #[derive(Clone, Eq, PartialEq)]
 #[cfg_attr(any(test, feature = "testutils"), derive(Debug))]
 struct LegacyEscrow {
+    pub id: u64,
+    pub buyer: Address,
+    pub seller: Address,
+    pub token: Address,
+    pub amount: i128,
+    pub status: EscrowStatus,
+    pub release_window: u32,
+    pub created_at: u32,
+    pub ipfs_hash: Option<String>,
+    pub metadata_hash: Option<Bytes>,
+    pub dispute_reason: Option<String>,
+    pub dispute_initiated_at: Option<u64>,
+}
+
+#[contracttype]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "testutils"), derive(Debug))]
+struct EscrowWithoutBatch {
+    pub version: u32,
     pub id: u64,
     pub buyer: Address,
     pub seller: Address,
@@ -1205,6 +1225,7 @@ impl EscrowContract {
         let escrow = Escrow {
             version: CURRENT_ESCROW_VERSION,
             id: order_id as u64,
+            batch_id: None,
             buyer: buyer.clone(),
             seller: seller.clone(),
             token: token.clone(),
@@ -1463,7 +1484,17 @@ impl EscrowContract {
         let version_key = Symbol::new(env, "version");
 
         if map.contains_key(version_key) {
-            let mut escrow = Escrow::try_from_val(env, &stored).expect("");
+            let batch_id_key = Symbol::new(env, "batch_id");
+            if map.contains_key(batch_id_key) {
+                let mut escrow = Escrow::try_from_val(env, &stored).expect("");
+                if escrow.version < CURRENT_ESCROW_VERSION {
+                    escrow.version = CURRENT_ESCROW_VERSION;
+                }
+                return escrow;
+            }
+
+            let previous = EscrowWithoutBatch::try_from_val(env, &stored).expect("");
+            let mut escrow = Self::escrow_from_without_batch(previous);
             if escrow.version < CURRENT_ESCROW_VERSION {
                 escrow.version = CURRENT_ESCROW_VERSION;
             }
@@ -1474,6 +1505,7 @@ impl EscrowContract {
         Escrow {
             version: CURRENT_ESCROW_VERSION,
             id: legacy.id,
+            batch_id: None,
             buyer: legacy.buyer,
             seller: legacy.seller,
             token: legacy.token,
@@ -1495,7 +1527,13 @@ impl EscrowContract {
         let version_key = Symbol::new(env, "version");
 
         if map.contains_key(version_key) {
-            let escrow = Escrow::try_from_val(env, &stored).expect("");
+            let batch_id_key = Symbol::new(env, "batch_id");
+            let escrow = if map.contains_key(batch_id_key) {
+                Escrow::try_from_val(env, &stored).expect("")
+            } else {
+                let previous = EscrowWithoutBatch::try_from_val(env, &stored).expect("");
+                Self::escrow_from_without_batch(previous)
+            };
             if escrow.version < CURRENT_ESCROW_VERSION {
                 return Self::upgrade_escrow(env, order_id, escrow);
             }
@@ -1507,6 +1545,7 @@ impl EscrowContract {
         let upgraded = Escrow {
             version: CURRENT_ESCROW_VERSION,
             id: legacy.id,
+            batch_id: None,
             buyer: legacy.buyer,
             seller: legacy.seller,
             token: legacy.token,
@@ -1530,6 +1569,25 @@ impl EscrowContract {
         env.storage().persistent().set(&key, &escrow);
         Self::extend_persistent(env, &key);
         escrow
+    }
+
+    fn escrow_from_without_batch(escrow: EscrowWithoutBatch) -> Escrow {
+        Escrow {
+            version: escrow.version,
+            id: escrow.id,
+            batch_id: None,
+            buyer: escrow.buyer,
+            seller: escrow.seller,
+            token: escrow.token,
+            amount: escrow.amount,
+            status: escrow.status,
+            release_window: escrow.release_window,
+            created_at: escrow.created_at,
+            ipfs_hash: escrow.ipfs_hash,
+            metadata_hash: escrow.metadata_hash,
+            dispute_reason: escrow.dispute_reason,
+            dispute_initiated_at: escrow.dispute_initiated_at,
+        }
     }
 
     /// Calculate platform fee for a given amount
@@ -2462,7 +2520,11 @@ impl EscrowContract {
     /// Create a single escrow from parameters (internal helper)
     /// Note: For batch operations, buyer/seller escrow list updates are consolidated
     /// by the caller to minimize storage writes (Issue #111)
-    fn create_single_escrow(env: &Env, params: EscrowCreateParams) -> Result<u64, Error> {
+    fn create_single_escrow(
+        env: &Env,
+        params: EscrowCreateParams,
+        batch_id: Option<u64>,
+    ) -> Result<u64, Error> {
         // Validate first
         Self::validate_escrow_params(env, &params)?;
 
@@ -2481,6 +2543,7 @@ impl EscrowContract {
         let escrow = Escrow {
             version: CURRENT_ESCROW_VERSION,
             id: params.order_id as u64,
+            batch_id,
             buyer: params.buyer.clone(),
             seller: params.seller.clone(),
             token: params.token.clone(),
@@ -2571,7 +2634,7 @@ impl EscrowContract {
     /// - Any validation error from individual escrows
     pub fn create_batch_escrow(
         env: Env,
-        _batch_id: u64,
+        batch_id: u64,
         escrows: soroban_sdk::Vec<EscrowCreateParams>,
     ) -> Result<soroban_sdk::Vec<u64>, Error> {
         Self::enter_reentry_guard(&env);
@@ -2609,7 +2672,7 @@ impl EscrowContract {
         // Create all escrows
         for i in 0..escrows.len() {
             if let Some(params) = escrows.get(i) {
-                match Self::create_single_escrow(&env, params.clone()) {
+                match Self::create_single_escrow(&env, params.clone(), Some(batch_id)) {
                     Ok(id) => {
                         let buyer_key = params.buyer.clone();
                         let seller_key = params.seller.clone();

--- a/craft-nexus-contract/src/onboarding.rs
+++ b/craft-nexus-contract/src/onboarding.rs
@@ -119,6 +119,15 @@ pub struct UserMetrics {
     pub total_volume: i128,
 }
 
+#[contracttype]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "testutils"), derive(Debug))]
+pub struct UserOnboardedEvent {
+    pub user: Address,
+    pub username: String,
+    pub role: UserRole,
+}
+
 /// A single entry in a user's verification history log (#63)
 #[contracttype]
 #[derive(Clone, Eq, PartialEq)]
@@ -756,11 +765,17 @@ impl OnboardingContract {
         env.storage()
             .persistent()
             .set(&DataKey::Username(normalized.clone()), &user);
-        Self::extend_persistent(&env, &DataKey::Username(normalized));
+        Self::extend_persistent(&env, &DataKey::Username(normalized.clone()));
 
         // Emit event
-        env.events()
-            .publish((Symbol::new(&env, "UserOnboarded"),), &user);
+        env.events().publish(
+            (Symbol::new(&env, "UserOnboarded"),),
+            UserOnboardedEvent {
+                user: user.clone(),
+                username: normalized,
+                role,
+            },
+        );
 
         profile
     }

--- a/craft-nexus-contract/src/onboarding.rs
+++ b/craft-nexus-contract/src/onboarding.rs
@@ -149,6 +149,8 @@ pub struct OnboardingConfig {
     pub min_username_length: u32,
     pub max_username_length: u32,
     pub platform_admin: Address,
+    /// Whether threshold-based verification should run automatically.
+    pub auto_verify_enabled: bool,
     /// Minimum completed escrow count for auto-verification (#63; default 5)
     pub min_escrow_count_for_verify: u32,
     /// Minimum total USDC volume (in stroops) for auto-verification (#63; default 10_000_000_000)
@@ -639,6 +641,7 @@ impl OnboardingContract {
             min_username_length: 3,
             max_username_length: 50,
             platform_admin: admin.clone(),
+            auto_verify_enabled: true,
             min_escrow_count_for_verify: 5,
             min_volume_for_verify: 10_000_000_000, // 1000 USDC at 7 decimals
             escrow_contract: None,
@@ -1074,6 +1077,22 @@ impl OnboardingContract {
         Self::extend_persistent(&env, &DataKey::Config);
     }
 
+    /// Enable or disable threshold-based automatic verification (admin only).
+    pub fn set_auto_verify_enabled(env: Env, enabled: bool) {
+        let mut config: OnboardingConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
+        Self::extend_persistent(&env, &DataKey::Config);
+
+        config.platform_admin.require_auth();
+        config.auto_verify_enabled = enabled;
+
+        env.storage().persistent().set(&DataKey::Config, &config);
+        Self::extend_persistent(&env, &DataKey::Config);
+    }
+
     /// Get activity metrics for a user.
     /// Returns zeroed metrics if no escrow activity has been recorded yet.
     pub fn get_user_metrics(env: Env, address: Address) -> UserMetrics {
@@ -1141,7 +1160,9 @@ impl OnboardingContract {
         Self::extend_persistent(&env, &key);
 
         // Check whether the user now meets the auto-verification threshold.
-        Self::try_auto_verify(&env, &address, &config, &metrics);
+        if config.auto_verify_enabled {
+            Self::try_auto_verify(&env, &address, &config, &metrics);
+        }
     }
 
     /// Internal helper: verify a user automatically if they meet the configured thresholds.
@@ -1205,6 +1226,10 @@ impl OnboardingContract {
             .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
         Self::extend_persistent(&env, &DataKey::Config);
 
+        if !config.auto_verify_enabled {
+            return false;
+        }
+
         let profile_key = DataKey::UserProfile(address.clone());
         let profile: UserProfile = env
             .storage()
@@ -1226,7 +1251,8 @@ impl OnboardingContract {
                 total_volume: 0,
             });
 
-        if metrics.total_escrow_count >= config.min_escrow_count_for_verify
+        if config.auto_verify_enabled
+            && metrics.total_escrow_count >= config.min_escrow_count_for_verify
             && metrics.total_volume >= config.min_volume_for_verify
         {
             Self::try_auto_verify(&env, &address, &config, &metrics);

--- a/craft-nexus-contract/src/onboarding_test.rs
+++ b/craft-nexus-contract/src/onboarding_test.rs
@@ -553,6 +553,35 @@ fn test_auto_verify_triggers_on_threshold() {
     assert_eq!(metrics.total_volume, 10_000_000_000);
 }
 
+#[test]
+fn test_auto_verify_can_be_disabled() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, _) = setup_test(&env);
+    let user = Address::generate(&env);
+    client.onboard_user(
+        &user,
+        &String::from_str(&env, "manualonly"),
+        &UserRole::Artisan,
+    );
+
+    client.set_auto_verify_enabled(&false);
+
+    let token_admin = Address::generate(&env);
+    let token = env.register_stellar_asset_contract_v2(token_admin);
+    client.update_user_metrics(&user, &5u32, &10_000_000_000i128, &token.address());
+
+    assert!(!client.is_verified(&user));
+    assert!(!client.auto_verify_user(&user));
+
+    client.verify_user(&user);
+    assert!(client.is_verified(&user));
+
+    let config = client.get_config();
+    assert!(!config.auto_verify_enabled);
+}
+
 /// auto_verify_user is a no-op on an already verified user.
 #[test]
 fn test_auto_verify_no_op_when_already_verified() {

--- a/craft-nexus-contract/src/scalability_test.rs
+++ b/craft-nexus-contract/src/scalability_test.rs
@@ -97,25 +97,25 @@ fn test_indexed_storage_scalability() {
     assert_eq!(count, 100);
 
     // Test pagination - first page
-    let page1 = client.get_escrows_by_buyer(&buyer, &0, &10).unwrap();
+    let page1 = client.get_escrows_by_buyer(&buyer, &0, &10, &false).unwrap();
     assert_eq!(page1.len(), 10);
     assert_eq!(page1.get_unchecked(0), 1);
     assert_eq!(page1.get_unchecked(9), 10);
 
     // Test pagination - middle page
-    let page5 = client.get_escrows_by_buyer(&buyer, &5, &10).unwrap();
+    let page5 = client.get_escrows_by_buyer(&buyer, &5, &10, &false).unwrap();
     assert_eq!(page5.len(), 10);
     assert_eq!(page5.get_unchecked(0), 51);
     assert_eq!(page5.get_unchecked(9), 60);
 
     // Test pagination - last page
-    let page10 = client.get_escrows_by_buyer(&buyer, &9, &10).unwrap();
+    let page10 = client.get_escrows_by_buyer(&buyer, &9, &10, &false).unwrap();
     assert_eq!(page10.len(), 10);
     assert_eq!(page10.get_unchecked(0), 91);
     assert_eq!(page10.get_unchecked(9), 100);
 
     // Test pagination - beyond last page
-    let page11 = client.get_escrows_by_buyer(&buyer, &10, &10).unwrap();
+    let page11 = client.get_escrows_by_buyer(&buyer, &10, &10, &false).unwrap();
     assert_eq!(page11.len(), 0);
 
     // Verify individual indexed entries exist
@@ -183,11 +183,11 @@ fn test_indexed_storage_multiple_users() {
     assert_eq!(count2, 30);
 
     // Verify buyer1 escrows
-    let buyer1_escrows = client.get_escrows_by_buyer(&buyer1, &0, &100).unwrap();
+    let buyer1_escrows = client.get_escrows_by_buyer(&buyer1, &0, &100, &false).unwrap();
     assert_eq!(buyer1_escrows.len(), 50);
 
     // Verify buyer2 escrows
-    let buyer2_escrows = client.get_escrows_by_buyer(&buyer2, &0, &100).unwrap();
+    let buyer2_escrows = client.get_escrows_by_buyer(&buyer2, &0, &100, &false).unwrap();
     assert_eq!(buyer2_escrows.len(), 30);
 
     // Verify no cross-contamination
@@ -230,7 +230,7 @@ fn test_migration_from_legacy_storage() {
     assert!(!env.storage().persistent().has(&legacy_key));
 
     // Verify query function works with migrated data
-    let escrows = client.get_escrows_by_buyer(&buyer, &0, &10).unwrap();
+    let escrows = client.get_escrows_by_buyer(&buyer, &0, &10, &false).unwrap();
     assert_eq!(escrows.len(), 3);
     assert_eq!(escrows.get_unchecked(0), 1);
     assert_eq!(escrows.get_unchecked(1), 2);
@@ -250,19 +250,19 @@ fn test_backward_compatibility_query() {
     env.storage().persistent().set(&legacy_key, &legacy_vec);
 
     // Query should work with legacy storage (backward compatibility)
-    let escrows = client.get_escrows_by_buyer(&buyer, &0, &10).unwrap();
+    let escrows = client.get_escrows_by_buyer(&buyer, &0, &10, &false).unwrap();
     assert_eq!(escrows.len(), 3);
     assert_eq!(escrows.get_unchecked(0), 10);
     assert_eq!(escrows.get_unchecked(1), 20);
     assert_eq!(escrows.get_unchecked(2), 30);
 
     // Test pagination with legacy storage
-    let page1 = client.get_escrows_by_buyer(&buyer, &0, &2).unwrap();
+    let page1 = client.get_escrows_by_buyer(&buyer, &0, &2, &false).unwrap();
     assert_eq!(page1.len(), 2);
     assert_eq!(page1.get_unchecked(0), 10);
     assert_eq!(page1.get_unchecked(1), 20);
 
-    let page2 = client.get_escrows_by_buyer(&buyer, &1, &2).unwrap();
+    let page2 = client.get_escrows_by_buyer(&buyer, &1, &2, &false).unwrap();
     assert_eq!(page2.len(), 1);
     assert_eq!(page2.get_unchecked(0), 30);
 }
@@ -303,7 +303,7 @@ fn test_batch_create_with_indexed_storage() {
     }
 
     // Verify query returns all escrows
-    let escrows = client.get_escrows_by_buyer(&buyer, &0, &100).unwrap();
+    let escrows = client.get_escrows_by_buyer(&buyer, &0, &100, &false).unwrap();
     assert_eq!(escrows.len(), 10);
 }
 
@@ -331,10 +331,10 @@ fn test_no_storage_limit_with_indexed_pattern() {
     assert_eq!(count, 500);
 
     // Verify we can still query efficiently
-    let page1 = client.get_escrows_by_buyer(&buyer, &0, &50).unwrap();
+    let page1 = client.get_escrows_by_buyer(&buyer, &0, &50, &false).unwrap();
     assert_eq!(page1.len(), 50);
 
-    let page10 = client.get_escrows_by_buyer(&buyer, &9, &50).unwrap();
+    let page10 = client.get_escrows_by_buyer(&buyer, &9, &50, &false).unwrap();
     assert_eq!(page10.len(), 50);
     assert_eq!(page10.get_unchecked(0), 451);
     assert_eq!(page10.get_unchecked(49), 500);

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -1483,11 +1483,13 @@ fn test_get_escrow_migrates_legacy_state() {
     let escrow = client.get_escrow(&77);
     assert_eq!(escrow.version, CURRENT_ESCROW_VERSION);
     assert_eq!(escrow.amount, 123);
+    assert_eq!(escrow.batch_id, None);
 
     let stored: Escrow = env.as_contract(&client.address, || {
         env.storage().persistent().get(&(ESCROW, 77u32)).unwrap()
     });
     assert_eq!(stored.version, CURRENT_ESCROW_VERSION);
+    assert_eq!(stored.batch_id, None);
 }
 
 #[test]
@@ -1589,14 +1591,17 @@ fn test_create_batch_escrow_success() {
     let escrow1 = client.get_escrow(&100);
     assert_eq!(escrow1.amount, 100_000_000);
     assert_eq!(escrow1.status, EscrowStatus::Active);
+    assert_eq!(escrow1.batch_id, Some(batch_id));
 
     let escrow2 = client.get_escrow(&101);
     assert_eq!(escrow2.amount, 200_000_000);
     assert_eq!(escrow2.status, EscrowStatus::Active);
+    assert_eq!(escrow2.batch_id, Some(batch_id));
 
     let escrow3 = client.get_escrow(&102);
     assert_eq!(escrow3.amount, 150_000_000);
     assert_eq!(escrow3.release_window, 604800); // Default 7 days
+    assert_eq!(escrow3.batch_id, Some(batch_id));
 
     // Verify events were emitted
     let events = env.events().all();

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -1280,25 +1280,25 @@ fn test_escrow_search_by_buyer() {
     client.create_escrow(&buyer, &seller, &token_id, &30_000_000, &3, &None);
 
     // Get all (limit 10)
-    let b1 = client.get_escrows_by_buyer(&buyer, &0, &10);
+    let b1 = client.get_escrows_by_buyer(&buyer, &0, &10, &false);
     assert_eq!(b1.len(), 3);
     assert_eq!(b1.get_unchecked(0), 1);
     assert_eq!(b1.get_unchecked(1), 2);
     assert_eq!(b1.get_unchecked(2), 3);
 
     // Pagination: page 0, limit 2
-    let b2 = client.get_escrows_by_buyer(&buyer, &0, &2);
+    let b2 = client.get_escrows_by_buyer(&buyer, &0, &2, &false);
     assert_eq!(b2.len(), 2);
     assert_eq!(b2.get_unchecked(0), 1);
     assert_eq!(b2.get_unchecked(1), 2);
 
     // Pagination: page 1, limit 2
-    let b3 = client.get_escrows_by_buyer(&buyer, &1, &2);
+    let b3 = client.get_escrows_by_buyer(&buyer, &1, &2, &false);
     assert_eq!(b3.len(), 1);
     assert_eq!(b3.get_unchecked(0), 3);
 
     // Pagination: out of bounds
-    let b4 = client.get_escrows_by_buyer(&buyer, &2, &2);
+    let b4 = client.get_escrows_by_buyer(&buyer, &2, &2, &false);
     assert_eq!(b4.len(), 0);
 }
 
@@ -1317,19 +1317,47 @@ fn test_escrow_search_by_seller() {
     client.create_escrow(&buyer, &seller, &token_id, &30_000_000, &3, &None);
 
     // Check seller 1
-    let s1 = client.get_escrows_by_seller(&seller, &0, &10);
+    let s1 = client.get_escrows_by_seller(&seller, &0, &10, &false);
     assert_eq!(s1.len(), 2);
     assert_eq!(s1.get_unchecked(0), 1);
     assert_eq!(s1.get_unchecked(1), 3);
 
     // Check seller 2
-    let s2 = client.get_escrows_by_seller(&seller2, &0, &10);
+    let s2 = client.get_escrows_by_seller(&seller2, &0, &10, &false);
     assert_eq!(s2.len(), 1);
     assert_eq!(s2.get_unchecked(0), 2);
 
     // Check non-existent seller
-    let s3 = client.get_escrows_by_seller(&Address::generate(&env), &0, &10);
+    let s3 = client.get_escrows_by_seller(&Address::generate(&env), &0, &10, &false);
     assert_eq!(s3.len(), 0);
+}
+
+#[test]
+fn test_escrow_search_reverse_pagination() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, token_admin, _, _) = setup_test(&env, true);
+
+    token_admin.mint(&buyer, &200_000_000);
+
+    client.create_escrow(&buyer, &seller, &token_id, &10_000_000, &1, &None);
+    client.create_escrow(&buyer, &seller, &token_id, &20_000_000, &2, &None);
+    client.create_escrow(&buyer, &seller, &token_id, &30_000_000, &3, &None);
+
+    let buyer_page_1 = client.get_escrows_by_buyer(&buyer, &0, &2, &true);
+    assert_eq!(buyer_page_1.len(), 2);
+    assert_eq!(buyer_page_1.get_unchecked(0), 3);
+    assert_eq!(buyer_page_1.get_unchecked(1), 2);
+
+    let buyer_page_2 = client.get_escrows_by_buyer(&buyer, &1, &2, &true);
+    assert_eq!(buyer_page_2.len(), 1);
+    assert_eq!(buyer_page_2.get_unchecked(0), 1);
+
+    let seller_page = client.get_escrows_by_seller(&seller, &0, &3, &true);
+    assert_eq!(seller_page.len(), 3);
+    assert_eq!(seller_page.get_unchecked(0), 3);
+    assert_eq!(seller_page.get_unchecked(1), 2);
+    assert_eq!(seller_page.get_unchecked(2), 1);
 }
 
 #[test]
@@ -2222,11 +2250,11 @@ fn test_create_batch_escrow_consolidates_storage() {
     assert_eq!(results.len(), 10);
 
     // Verify buyer's escrow list contains all 10
-    let buyer_escrows = client.get_escrows_by_buyer(&buyer, &0, &100);
+    let buyer_escrows = client.get_escrows_by_buyer(&buyer, &0, &100, &false);
     assert_eq!(buyer_escrows.len(), 10);
 
     // Verify seller's escrow list contains all 10
-    let seller_escrows = client.get_escrows_by_seller(&seller, &0, &100);
+    let seller_escrows = client.get_escrows_by_seller(&seller, &0, &100, &false);
     assert_eq!(seller_escrows.len(), 10);
 }
 
@@ -2980,4 +3008,3 @@ fn test_accept_partial_refund_with_custom_fee_tier() {
     let token_client = token::Client::new(&env, &token_id);
     assert_eq!(token_client.balance(&seller), 490);
 }
-


### PR DESCRIPTION
## Summary

- Added `reverse: bool` pagination support to `get_escrows_by_buyer` and `get_escrows_by_seller` so callers can retrieve latest escrows first.
- Updated `UserOnboarded` events to include user address, normalized username, and role.
- Added `batch_id: Option<u64>` to `Escrow` and stores `Some(batch_id)` for escrows created through `create_batch_escrow`.
- Added `auto_verify_enabled` to `OnboardingConfig`, defaulting to enabled, plus an admin setter to disable automatic verification without a WASM upgrade.

## Related Issues
Closes #182 
Closes #183 
Closes #185 
Closes #186 