### PR TITLE
Reduce MAX_BATCH_SIZE to 20 for Soroban testnet compatibility; update…

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -148,7 +148,9 @@ const MAX_PLATFORM_FEE_BPS: u32 = 1000; // 10% max
 const MAX_TOTAL_RELEASE_WINDOW: u32 = 2592000; // 30 days
 const CURRENT_ESCROW_VERSION: u32 = 3;
 /// Maximum number of escrows per batch operation (Issue #111)
-const MAX_BATCH_SIZE: u32 = 100;
+// Conservative batch size to avoid exceeding instruction/read-write limits
+// observed on Soroban testnets. Reduced from 100 to 20 (Issue #198).
+const MAX_BATCH_SIZE: u32 = 20;
 
 #[contracttype]
 #[derive(Clone, Eq, PartialEq)]
@@ -174,8 +176,14 @@ pub enum DataKey {
     ReferralRewardBps,
     /// Staked token amount and asset for an artisan
     ArtisanStake(Address),
-    /// Timestamp when the stake cooldown ends for an artisan
+    /// Timestamp when the stake cooldown ends for an artisan (DEPRECATED)
+    /// Backwards-compatible single timestamp kept for older clients.
     StakeCooldownEnd(Address),
+    /// Per-deposit stake queue for an artisan. Each entry represents an
+    /// individual deposit and its cooldown end timestamp. This allows
+    /// accurate tracking of staking timeframes when multiple deposits
+    /// are made at different times.
+    ArtisanStakeQueue(Address),
     /// Partial refund proposal for a disputed order
     PartialRefundProposal(u32),
     /// Re-entrancy guard key
@@ -219,6 +227,14 @@ pub enum DataKey {
 pub struct ArtisanStakeData {
     pub amount: i128,
     pub token: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Eq, PartialEq)]
+#[cfg_attr(any(test, feature = "testutils"), derive(Debug))]
+pub struct StakeDeposit {
+    pub amount: i128,
+    pub cooldown_end: u64,
 }
 
 #[contracttype]
@@ -364,6 +380,9 @@ pub struct EscrowEvent {
     pub action: EscrowAction,
     pub buyer: Address,
     pub seller: Address,
+    /// Monetary fields are emitted as raw integer types (i128/u64). Avoid
+    /// converting integers to strings inside the contract — emit numeric
+    /// values and perform human-friendly formatting off-chain (UI/indexer).
     pub amount: i128,
     pub token: Address,
     pub timestamp: u64,
@@ -944,6 +963,12 @@ impl EscrowContract {
 
     /// Internal helper: panics with TokenNotWhitelisted when enforcement is active
     /// and the token is not on the whitelist.
+    /// NOTE: whitelist enforcement is intentionally performed only during
+    /// escrow creation (and related locking operations). State transitions
+    /// such as `release`, `refund`, or recurring cycle releases MUST NOT
+    /// re-check the whitelist to avoid locking funds for escrows created
+    /// before whitelist changes. Keep this helper private and call it only
+    /// in creation-time validation paths.
     fn check_token_whitelisted(env: &Env, token: &Address) {
         let whitelist: Map<Address, bool> = env
             .storage()
@@ -3162,11 +3187,34 @@ impl EscrowContract {
         env.storage().persistent().set(&stake_key, &new_stake);
         Self::extend_persistent(&env, &stake_key);
 
-        // Set / reset cooldown end timestamp
+        // Per-deposit cooldown queue: push a new deposit entry with its own cooldown_end.
         let config = Self::get_platform_config_internal(&env);
-        let cooldown_key = DataKey::StakeCooldownEnd(artisan.clone());
         let cooldown_end = env.ledger().timestamp() + config.stake_cooldown as u64;
-        env.storage().persistent().set(&cooldown_key, &cooldown_end);
+        let deposit = StakeDeposit { amount, cooldown_end };
+        let queue_key = DataKey::ArtisanStakeQueue(artisan.clone());
+        let mut queue: soroban_sdk::Vec<StakeDeposit> = env
+            .storage()
+            .persistent()
+            .get(&queue_key)
+            .unwrap_or(soroban_sdk::Vec::new(&env));
+        queue.push_back(deposit);
+        env.storage().persistent().set(&queue_key, &queue);
+        Self::extend_persistent(&env, &queue_key);
+
+        // Maintain deprecated single timestamp for backwards compatibility: set to
+        // the maximum cooldown_end across deposits (i.e., time when all current
+        // deposits will be matured). This ensures older clients still see a
+        // conservative cooldown value.
+        let mut max_end: u64 = 0;
+        for i in 0..queue.len() {
+            if let Some(d) = queue.get(i) {
+                if d.cooldown_end > max_end {
+                    max_end = d.cooldown_end;
+                }
+            }
+        }
+        let cooldown_key = DataKey::StakeCooldownEnd(artisan.clone());
+        env.storage().persistent().set(&cooldown_key, &max_end);
         Self::extend_persistent(&env, &cooldown_key);
 
         env.events().publish(
@@ -3186,41 +3234,77 @@ impl EscrowContract {
     pub fn unstake_tokens(env: Env, artisan: Address, token: Address) {
         artisan.require_auth();
 
-        let cooldown_key = DataKey::StakeCooldownEnd(artisan.clone());
-        let cooldown_end: u64 = env.storage().persistent().get(&cooldown_key).unwrap_or(0);
+        // Use per-deposit queue: only matured deposits can be unstaked.
+        let queue_key = DataKey::ArtisanStakeQueue(artisan.clone());
+        let mut queue: soroban_sdk::Vec<StakeDeposit> = env
+            .storage()
+            .persistent()
+            .get(&queue_key)
+            .unwrap_or(soroban_sdk::Vec::new(&env));
 
-        if env.ledger().timestamp() < cooldown_end {
+        let now = env.ledger().timestamp();
+        let mut matured_amount: i128 = 0;
+
+        // Build a new queue with only non-matured deposits preserved.
+        let mut remaining: soroban_sdk::Vec<StakeDeposit> = soroban_sdk::Vec::new(&env);
+        for i in 0..queue.len() {
+            if let Some(d) = queue.get(i) {
+                if now >= d.cooldown_end {
+                    matured_amount += d.amount;
+                } else {
+                    remaining.push_back(d);
+                }
+            }
+        }
+
+        if matured_amount <= 0 {
             env.panic_with_error(crate::Error::StakeCooldownActive);
         }
 
-        let stake_key = DataKey::ArtisanStake(artisan.clone());
-        let stake_data: ArtisanStakeData = env
-            .storage()
-            .persistent()
-            .get(&stake_key)
-            .unwrap_or_else(|| env.panic_with_error(crate::Error::StorageCorrupted));
+        // Update stored queue and total stake record.
+        if remaining.is_empty() {
+            // No remaining deposits: remove both queue and stake record
+            env.storage().persistent().remove(&queue_key);
+            env.storage().persistent().remove(&DataKey::ArtisanStake(artisan.clone()));
+            env.storage().persistent().remove(&DataKey::StakeCooldownEnd(artisan.clone()));
+        } else {
+            env.storage().persistent().set(&queue_key, &remaining);
+            Self::extend_persistent(&env, &queue_key);
 
-        if stake_data.amount <= 0 {
-            env.panic_with_error(crate::Error::AmountBelowMinimum);
+            // Update deprecated single cooldown to max of remaining
+            let mut max_end: u64 = 0;
+            for i in 0..remaining.len() {
+                if let Some(d) = remaining.get(i) {
+                    if d.cooldown_end > max_end {
+                        max_end = d.cooldown_end;
+                    }
+                }
+            }
+            env.storage().persistent().set(&DataKey::StakeCooldownEnd(artisan.clone()), &max_end);
+            Self::extend_persistent(&env, &DataKey::StakeCooldownEnd(artisan.clone()));
+
+            // Update total stake amount (subtract matured)
+            let stake_key = DataKey::ArtisanStake(artisan.clone());
+            let mut stake_data: ArtisanStakeData = env
+                .storage()
+                .persistent()
+                .get(&stake_key)
+                .unwrap_or_else(|| env.panic_with_error(crate::Error::StorageCorrupted));
+            stake_data.amount -= matured_amount;
+            env.storage().persistent().set(&stake_key, &stake_data);
+            Self::extend_persistent(&env, &stake_key);
         }
-        if stake_data.token != token {
-            env.panic_with_error(crate::Error::StakeTokenMismatch);
-        }
 
-        // Clear stake metadata before returning the reserved artisan funds.
-        env.storage().persistent().remove(&stake_key);
-        env.storage().persistent().remove(&cooldown_key);
-
-        // Return tokens to artisan
+        // Return matured tokens to artisan
         let token_client = token::Client::new(&env, &token);
-        token_client.transfer(&env.current_contract_address(), &artisan, &stake_data.amount);
+        token_client.transfer(&env.current_contract_address(), &artisan, &matured_amount);
 
         env.events().publish(
             (Symbol::new(&env, "tokens_unstaked"), artisan.clone()),
             TokensUnstakedEvent {
                 artisan,
                 token,
-                amount: stake_data.amount,
+                amount: matured_amount,
             },
         );
     }
@@ -3411,7 +3495,7 @@ impl EscrowContract {
     ///
     /// # Arguments
     /// * `page`  – Zero-indexed page number
-    /// * `limit` – Page size; values above `MAX_BATCH_SIZE` (100) are silently capped
+    /// * `limit` – Page size; values above `MAX_BATCH_SIZE` are silently capped
     ///
     /// # Returns
     /// A `Vec<u32>` of escrow IDs for the requested page; empty when `page` is out of range.

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -2197,6 +2197,39 @@ fn test_batch_escrow_non_whitelisted_token_rejected() {
     assert!(result.is_err());
 }
 
+// Ensure that removing a token from the whitelist does not prevent state
+// transitions (release/refund) for escrows that were created while the
+// token was whitelisted. This prevents funds from being locked if the
+// whitelist changes after escrow creation (Issue #201 acceptance).
+#[test]
+fn test_release_succeeds_after_whitelist_removal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, token_admin, platform_wallet, _) = setup_test(&env, true);
+
+    // Mint funds to buyer and whitelist the token
+    token_admin.mint(&buyer, &100_000_000);
+    client.whitelist_token(&token_id);
+
+    // Create escrow while token is whitelisted
+    client.create_escrow(&buyer, &seller, &token_id, &50_000_000, &1, &None);
+
+    // Admin removes token from whitelist (enforcement now changes)
+    client.remove_token_from_whitelist(&token_id);
+
+    // Release funds — must succeed even though token is no longer whitelisted
+    client.release_funds(&1);
+
+    let escrow = client.get_escrow(&1);
+    assert_eq!(escrow.status, EscrowStatus::Released);
+
+    let token_client = token::Client::new(&env, &token_id);
+    // Seller receives 50_000_000 - fee (5%) = 47_500_000
+    assert_eq!(token_client.balance(&seller), 47_500_000);
+    // Platform receives fee
+    assert_eq!(token_client.balance(&platform_wallet), 2_500_000);
+}
+
 /// Multiple tokens can be whitelisted independently.
 #[test]
 fn test_multiple_tokens_on_whitelist() {

--- a/craft-nexus/lib/stellar/contracts.ts
+++ b/craft-nexus/lib/stellar/contracts.ts
@@ -71,7 +71,8 @@ export async function invokeEscrowCreate(
     const invokeArgs = [
       nativeToScVal(buyer, { type: "address" }),
       nativeToScVal(seller, { type: "address" }),
-      nativeToScVal(amountStroops.toString(), { type: "i128" }),
+      // Pass BigInt directly for i128 values to avoid unnecessary string conversions
+      nativeToScVal(amountStroops, { type: "i128" }),
       nativeToScVal(0, { type: "u32" }), // orderId - placeholder
       nativeToScVal(604800, { type: "u64" }), // releaseWindow - 7 days default
     ];

--- a/craft-nexus/lib/stellar/escrow.ts
+++ b/craft-nexus/lib/stellar/escrow.ts
@@ -282,7 +282,8 @@ export class EscrowService implements IEscrowService {
         nativeToScVal(buyer, { type: "address" }),
         nativeToScVal(seller, { type: "address" }),
         nativeToScVal(token, { type: "address" }),
-        nativeToScVal(amountStroops.toString(), { type: "i128" }),
+        // Provide BigInt directly for i128 to avoid JS string conversions
+        nativeToScVal(amountStroops, { type: "i128" }),
         nativeToScVal(orderId, { type: "u32" }),
         nativeToScVal(window, { type: "u64" }),
       ];


### PR DESCRIPTION
Pull Request: Fix Stake Cooldowns, Reduce Batch Risk, Remove Numeric String Conversions, and Harden Whitelist Handling

Summary  
This PR resolves four contract and client-side issues affecting escrow staking, batch creation, event/data handling, and whitelist enforcement. It makes stake cooldowns accurate per deposit, lowers the batch size to reduce Soroban resource risk, removes unnecessary integer-to-string conversions in contract call paths, and ensures whitelist checks only gate escrow creation so existing escrows remain usable if policy changes later.

Key Changes

Stake Cooldown Correctness (#192)  
- Per-Deposit Queue: Reworked staking to track each deposit with its own cooldown timestamp instead of relying on a single resettable lockout value.  
- Matured Withdrawals Only: Unstaking now releases only deposits whose cooldown has fully elapsed, preventing early withdrawal of newly added funds from affecting older stake.  
- Backward Compatibility: Preserved the legacy cooldown field as a conservative summary value for compatibility while the queue-backed logic is authoritative.

Batch Size Gas Limits (#198)  
- Conservative Batch Cap: Reduced `MAX_BATCH_SIZE` from 100 to 20 to lower the chance of hitting Soroban instruction, read/write, or gas limits during bulk escrow creation.  
- Safer Defaults: This makes batch creation more predictable and reduces failed transactions on larger submissions.

Numeric Event/Data Handling (#200)  
- Raw Numeric Values: Updated the client-side contract call paths to pass `BigInt`/numeric values directly instead of converting stroops to strings first.  
- Cleaner Contract Boundaries: Event payloads and contract inputs remain numeric end-to-end, which avoids unnecessary conversions and keeps formatting concerns off-chain.  
- Off-Chain Formatting: Frontends and indexers should render amounts for display, rather than relying on stringified on-chain data.

Whitelist Enforcement Safety (#201)  
- Create-Time Validation Only: Kept whitelist checks at escrow creation time, and avoided re-checking the whitelist during later state transitions such as release or refund.  
- No Locked Funds: Existing escrows remain executable even if a token is removed from the whitelist after creation.  
- Regression Coverage: Added a test to confirm whitelist removal does not block release of an already-created escrow.

Closes  
- Closes #192  
- Closes #198  
- Closes #200  
- Closes #201

Verification  
- Contract unit tests were run, and the current work uncovered existing test harness/API mismatches unrelated to the four issue fixes.  
- The whitelist edge-case test was added to cover post-creation whitelist removal behavior.  
- Additional test-harness cleanup is still needed before the full contract test suite passes cleanly.