### PR TITLE
Add NFT and semi-fungible collateral support

### DIFF
--- a/.kiro/specs/nft-collateral-support/.config.kiro
+++ b/.kiro/specs/nft-collateral-support/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "654e8c78-42e1-45ba-893b-d13a1aa283e6", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/nft-collateral-support/design.md
+++ b/.kiro/specs/nft-collateral-support/design.md
@@ -1,0 +1,838 @@
+# Design Document: NFT and Semi-Fungible Collateral Support
+
+## Overview
+
+This document describes the design for adding NFT (Non-Fungible Token) and semi-fungible token support to the Craft Nexus escrow system. Currently, the system only supports standard fungible tokens (like USDC) for staking and escrow operations. This feature extends the system to handle multiple token standards while maintaining full backward compatibility.
+
+### Key Objectives
+
+1. **Token Standard Detection**: Automatically detect whether a token contract implements Fungible Token, NFT, or Semi-Fungible Token interfaces
+2. **Collateral Validation**: Validate ownership and availability of NFTs and semi-fungible tokens before accepting as collateral
+3. **Collateral Management**: Properly lock/unlock NFTs and track semi-fungible token balances during escrow
+4. **Backward Compatibility**: Maintain existing fungible token support without disruption
+5. **Metadata Handling**: Retrieve and store NFT metadata for reference
+6. **Gas Efficiency**: Minimize transaction costs through batching and caching
+
+### Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Collateral Service                            │
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐   │
+│  │  Token Detector  │  │  NFT Manager     │  │  Semi-Fungible   │   │
+│  │                  │  │                  │  │  Manager         │   │
+│  │ - Interface      │  │ - Ownership      │  │ - Balance        │   │
+│  │   Detection      │  │   Validation     │  │   Validation     │   │
+│  │ - Standard       │  │ - Lock/Unlock    │  │ - Lock/Unlock    │   │
+│  │   Identification │  │ - Metadata       │  │ - Balance Track  │   │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘   │
+│                              │                                        │
+│                              ▼                                        │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │                    Collateral Validator                         │  │
+│  │  - Validates ownership and availability                         │  │
+│  │  - Caches validation results                                    │  │
+│  │  - Returns descriptive errors                                   │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+│                              │                                        │
+│                              ▼                                        │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │                    Escrow Integration                           │  │
+│  │  - Unified collateral interface                                 │  │
+│  │  - Backward compatible with fungible tokens                     │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Architecture
+
+### Component Structure
+
+The collateral support feature is organized into the following components:
+
+```
+collateral/
+├── types.ts              # Shared types and interfaces
+├── detector.ts           # Token standard detection logic
+├── validator.ts          # Collateral validation
+├── nft/                  # NFT-specific logic
+│   ├── manager.ts        # NFT lock/unlock operations
+│   └── metadata.ts       # NFT metadata handling
+├── semi-fungible/        # Semi-fungible token logic
+│   └── manager.ts        # Semi-fungible balance management
+└── service.ts            # Unified collateral service
+```
+
+### Token Standard Detection Flow
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Token Standard Detection                          │
+├─────────────────────────────────────────────────────────────────────┤
+│ 1. Input: Token Contract Address                                     │
+│ 2. Query Contract for Available Interfaces                           │
+│ 3. Check for NFT Interfaces (highest priority)                       │
+│ 4. Check for Semi-Fungible Interfaces (medium priority)              │
+│ 5. Check for Fungible Token Interface (lowest priority)              │
+│ 6. Return TokenStandard with detected standard                       │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Data Flow
+
+```
+┌──────────────┐     ┌──────────────────┐     ┌──────────────────┐
+│   User       │────>│  Collateral      │────>│  Escrow          │
+│  Provides    │     │  Service         │     │  Service         │
+│  Collateral  │     │                  │     │                  │
+└──────────────┘     └──────────────────┘     └──────────────────┘
+                          │                            │
+                          ▼                            ▼
+                 ┌──────────────────┐          ┌──────────────────┐
+                 │  Token Detector  │          │  Collateral      │
+                 │                  │          │  Validator       │
+                 └──────────────────┘          └──────────────────┘
+                          │                            │
+                          ▼                            ▼
+                 ┌──────────────────┐          ┌──────────────────┐
+                 │  Token Standard  │          │  Validation      │
+                 │  Identified      │          │  Results         │
+                 └──────────────────┘          └───────��──────────┘
+```
+
+## Components and Interfaces
+
+### Core Types
+
+```typescript
+// Token standard enumeration
+export enum TokenStandard {
+  Fungible = "fungible_token",
+  NonFungible = "non_fungible_token",
+  SemiFungible = "semi_fungible_token",
+  Unknown = "unknown",
+}
+
+// Token contract interface identifiers
+export const TOKEN_INTERFACES = {
+  Fungible: ["fungible_token", "fungible_token_metadata"],
+  NonFungible: ["nft_metadata", "nft_core", "non_fungible_token"],
+  SemiFungible: ["sfungible_token", "semi_fungible_token"],
+};
+
+// Collateral type enumeration
+export enum CollateralType {
+  Fungible = "fungible",
+  NFT = "nft",
+  SemiFungible = "semi-fungible",
+}
+
+// Base collateral interface
+export interface Collateral {
+  type: CollateralType;
+  contractAddress: string;
+  owner: string;
+  validated: boolean;
+  validationTimestamp: number;
+}
+
+// NFT collateral
+export interface NFTCollateral extends Collateral {
+  type: CollateralType.NFT;
+  tokenId: string;
+  metadataUri?: string;
+  metadata?: NFTMetadata;
+}
+
+// Semi-fungible collateral
+export interface SemiFungibleCollateral extends Collateral {
+  type: CollateralType.SemiFungible;
+  tokenId: string;
+  quantity: bigint;
+}
+
+// Fungible collateral (existing)
+export interface FungibleCollateral extends Collateral {
+  type: CollateralType.Fungible;
+  amount: bigint;
+}
+
+// Unified collateral union type
+export type AnyCollateral =
+  | FungibleCollateral
+  | NFTCollateral
+  | SemiFungibleCollateral;
+```
+
+### Token Detector Interface
+
+```typescript
+export interface TokenDetector {
+  /**
+   * Detect the token standard for a given contract address
+   * @param contractAddress - The token contract address
+   * @returns TokenStandard with detected standard and interface info
+   */
+  detectStandard(contractAddress: string): Promise<TokenStandardInfo>;
+
+  /**
+   * Check if a contract implements a specific interface
+   * @param contractAddress - The token contract address
+   * @param interfaceName - The interface to check
+   * @returns True if the interface is implemented
+   */
+  hasInterface(
+    contractAddress: string,
+    interfaceName: string,
+  ): Promise<boolean>;
+
+  /**
+   * Get all available interfaces for a contract
+   * @param contractAddress - The token contract address
+   * @returns Array of interface names implemented by the contract
+   */
+  getAvailableInterfaces(contractAddress: string): Promise<string[]>;
+}
+
+export interface TokenStandardInfo {
+  standard: TokenStandard;
+  interfaces: string[];
+  priority: number; // Higher = more specific
+}
+```
+
+### Collateral Manager Interface
+
+```typescript
+export interface CollateralManager<T extends AnyCollateral> {
+  /**
+   * Validate that the user owns the collateral
+   * @param collateral - The collateral to validate
+   * @returns True if ownership is verified
+   */
+  validateOwnership(collateral: T): Promise<boolean>;
+
+  /**
+   * Lock the collateral for escrow
+   * @param collateral - The collateral to lock
+   * @param escrowId - The escrow ID
+   * @returns Transaction hash or result
+   */
+  lock(collateral: T, escrowId: number): Promise<TransactionResult>;
+
+  /**
+   * Unlock/release the collateral after escrow
+   * @param collateral - The collateral to unlock
+   * @param escrowId - The escrow ID
+   * @returns Transaction hash or result
+   */
+  unlock(collateral: T, escrowId: number): Promise<TransactionResult>;
+
+  /**
+   * Get the current balance/ownership status
+   * @param collateral - The collateral to check
+   * @returns Current balance or ownership status
+   */
+  getStatus(collateral: T): Promise<CollateralStatus>;
+}
+
+export interface TransactionResult {
+  success: boolean;
+  transactionHash?: string;
+  error?: string;
+}
+
+export interface CollateralStatus {
+  owner: string;
+  locked: boolean;
+  escrowId?: number;
+  timestamp: number;
+}
+```
+
+## Data Models
+
+### Collateral Storage Structure
+
+The escrow contract's collateral storage needs to be extended to support multiple token standards:
+
+```rust
+// Updated Collateral struct for the escrow contract
+#[derive(Clone, Debug, Encodable, Decodable, HasSpec, Serialize, Deserialize)]
+#[spec(type = "Collateral")]
+pub enum Collateral {
+    Fungible(FungibleCollateral),
+    NonFungible(NonFungibleCollateral),
+    SemiFungible(SemiFungibleCollateral),
+}
+
+// Fungible collateral (existing)
+#[derive(Clone, Debug, Encodable, Decodable, HasSpec, Serialize, Deserialize)]
+#[spec(type = "FungibleCollateral")]
+pub struct FungibleCollateral {
+    pub token_contract: Address,
+    pub amount: i128, // Stroops for Stellar tokens
+}
+
+// NFT collateral (new)
+#[derive(Clone, Debug, Encodable, Decodable, HasSpec, Serialize, Deserialize)]
+#[spec(type = "NonFungibleCollateral")]
+pub struct NonFungibleCollateral {
+    pub token_contract: Address,
+    pub token_id: BytesN<32>, // Token ID hash
+    pub metadata_uri: Option<String>,
+    pub metadata: Option<BytesN<32>>, // Hash of metadata for verification
+}
+
+// Semi-fungible collateral (new)
+#[derive(Clone, Debug, Encodable, Decodable, HasSpec, Serialize, Deserialize)]
+#[spec(type = "SemiFungibleCollateral")]
+pub struct SemiFungibleCollateral {
+    pub token_contract: Address,
+    pub token_id: BytesN<32>, // Token ID
+    pub quantity: i128,
+}
+```
+
+### Escrow Storage Extension
+
+```rust
+// Updated Escrow struct
+#[derive(Clone, Debug, Encodable, Decodable, HasSpec, Serialize, Deserialize)]
+#[spec(type = "Escrow")]
+pub struct Escrow {
+    pub buyer: Address,
+    pub seller: Address,
+    pub collateral: Collateral,
+    pub status: EscrowStatus,
+    pub created_at: i64,
+    pub release_window: u64,
+    pub order_id: u32,
+}
+
+// Escrow status (existing)
+#[derive(Clone, Debug, Encodable, Decodable, HasSpec, Serialize, Deserialize)]
+#[spec(type = "EscrowStatus")]
+pub enum EscrowStatus {
+    Pending,
+    Released,
+    Refunded,
+    Disputed,
+}
+```
+
+### Token Metadata Structure
+
+```typescript
+// NFT metadata structure (following ERC-721/ERC-1155 conventions)
+export interface NFTMetadata {
+  name: string;
+  description: string;
+  image?: string;
+  animation_url?: string;
+  attributes?: Attribute[];
+  external_url?: string;
+  [key: string]: unknown;
+}
+
+export interface Attribute {
+  trait_type: string;
+  value: string | number;
+  display_type?: string;
+}
+
+// Token standard interface definitions
+export interface TokenStandardInterfaces {
+  // Fungible Token (SIP-010)
+  fungible_token?: {
+    name: string;
+    symbol: string;
+    decimals: number;
+    total_supply: bigint;
+  };
+
+  // Non-Fungible Token (SIP-012)
+  nft_metadata?: {
+    name: string;
+    symbol: string;
+    token_id_required?: boolean;
+    metadata_required?: boolean;
+  };
+
+  // Semi-Fungible Token
+  semi_fungible_token?: {
+    name: string;
+    symbol: string;
+    total_supply: bigint;
+  };
+}
+```
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system-essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: Token Standard Detection Accuracy
+
+_For any_ valid token contract address, the token detector SHALL correctly identify the token standard based on implemented interfaces, with NFT interfaces taking priority over semi-fungible, and semi-fungible taking priority over fungible.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 6.4**
+
+### Property 2: NFT Ownership Validation
+
+_For any_ NFT collateral, the system SHALL only accept it as valid collateral if the user owns the specific NFT identified by the token contract address and token ID.
+
+**Validates: Requirements 1.1, 1.5**
+
+### Property 3: NFT Collateral Storage Integrity
+
+_For any_ NFT collateral that is pledged, the system SHALL correctly store the token contract address and token ID, and these values SHALL be recoverable when querying the escrow.
+
+**Validates: Requirements 1.2**
+
+### Property 4: NFT Transfer Prevention During Escrow
+
+_For any_ NFT pledged as collateral, the system SHALL prevent its transfer or sale while the escrow is in pending status, and the NFT SHALL be returned to the original owner upon escrow release or refund.
+
+**Validates: Requirements 1.3, 8.1, 8.3**
+
+### Property 5: Semi-Fungible Quantity Validation
+
+_For any_ semi-fungible collateral, the system SHALL validate that the requested quantity is available and non-zero before accepting it as collateral.
+
+**Validates: Requirements 2.4**
+
+### Property 6: Semi-Fungible Balance Tracking
+
+_For any_ semi-fungible collateral, the system SHALL correctly track the pledged quantity and prevent transfer of those specific units while the escrow is active.
+
+**Validates: Requirements 2.2, 2.3**
+
+### Property 7: Backward Compatibility with Fungible Tokens
+
+_For any_ fungible token contract, the system SHALL process it using the existing fungible token logic without applying NFT-specific validation, and error messages SHALL match the original behavior.
+
+**Validates: Requirements 5.1, 5.2, 5.5**
+
+### Property 8: Interface Priority Logic
+
+_For any_ token contract that implements multiple token standards, the system SHALL prioritize based on specificity (NFT > semi-fungible > fungible) unless explicitly specified otherwise.
+
+**Validates: Requirements 3.5, 5.4, 6.4**
+
+### Property 9: Metadata Retrieval and Caching
+
+_For any_ NFT used as collateral, if metadata is available, the system SHALL retrieve and cache the metadata URI for the duration of the escrow, and the cached metadata SHALL be included in escrow status queries.
+
+**Validates: Requirements 9.1, 9.2, 9.3**
+
+### Property 10: Gas Efficiency Through Batching
+
+_For any_ escrow involving multiple NFTs, the system SHALL batch operations where possible to minimize transaction costs, and cached data SHALL be reused instead of re-fetching.
+
+**Validates: Requirements 10.1, 10.2, 10.3**
+
+## Error Handling
+
+### Error Categories
+
+```typescript
+// Token detection errors
+export enum TokenDetectionError {
+  ContractNotFound = "CONTRACT_NOT_FOUND",
+  InterfaceNotFound = "INTERFACE_NOT_FOUND",
+  MultipleStandards = "MULTIPLE_STANDARDS",
+  UnknownStandard = "UNKNOWN_STANDARD",
+}
+
+// Collateral validation errors
+export enum CollateralValidationError {
+  OwnershipFailed = "OWNERSHIP_FAILED",
+  TokenIdNotFound = "TOKEN_ID_NOT_FOUND",
+  InsufficientBalance = "INSUFFICIENT_BALANCE",
+  InvalidQuantity = "INVALID_QUANTITY",
+}
+
+// Escrow operation errors
+export enum EscrowOperationError {
+  InvalidCollateral = "INVALID_COLLATERAL",
+  AlreadyLocked = "ALREADY_LOCKED",
+  NotOwner = "NOT_OWNER",
+  ReleaseWindowNotPassed = "RELEASE_WINDOW_NOT_PASSED",
+}
+
+// Unified error type
+export interface CollateralError {
+  code: TokenDetectionError | CollateralValidationError | EscrowOperationError;
+  message: string;
+  details?: Record<string, unknown>;
+  actionable?: boolean; // Whether the user can take action to resolve
+}
+```
+
+### Error Handling Strategy
+
+1. **Token Detection Errors**:
+   - Contract not found: Return descriptive error with contract address
+   - Interface not found: List expected interfaces
+   - Unknown standard: Provide guidance on supported standards
+
+2. **Validation Errors**:
+   - Ownership failed: Explain how to verify ownership
+   - Token ID not found: Provide valid token ID format
+   - Insufficient balance: Show available balance vs required
+
+3. **Operation Errors**:
+   - Invalid collateral: Specify what makes it invalid
+   - Already locked: Provide escrow ID and status
+   - Not owner: Show current owner address
+
+### Error Message Guidelines
+
+All error messages MUST:
+
+- Be descriptive and actionable
+- Include the specific field that failed validation
+- Provide guidance on how to resolve the issue
+- Log the error for debugging with sensitive data redacted
+
+## Testing Strategy
+
+### Unit Tests
+
+#### Token Standard Detection Tests
+
+```typescript
+describe("TokenDetector", () => {
+  describe("detectStandard", () => {
+    it("should detect NFT standard for NFT contract", async () => {
+      // Test with NFT contract
+    });
+
+    it("should detect semi-fungible standard for semi-fungible contract", async () => {
+      // Test with semi-fungible contract
+    });
+
+    it("should detect fungible standard for fungible contract", async () => {
+      // Test with fungible contract
+    });
+
+    it("should return unknown for unsupported contract", async () => {
+      // Test with unsupported contract
+    });
+
+    it("should prioritize NFT over other standards", async () => {
+      // Test with contract implementing multiple standards
+    });
+  });
+
+  describe("hasInterface", () => {
+    it("should return true for implemented interface", async () => {
+      // Test interface detection
+    });
+
+    it("should return false for non-implemented interface", async () => {
+      // Test non-existent interface
+    });
+  });
+});
+```
+
+#### Collateral Validation Tests
+
+```typescript
+describe("CollateralValidator", () => {
+  describe("validateOwnership", () => {
+    it("should validate NFT ownership correctly", async () => {
+      // Test NFT ownership validation
+    });
+
+    it("should validate semi-fungible ownership correctly", async () => {
+      // Test semi-fungible ownership validation
+    });
+
+    it("should reject non-owned collateral", async () => {
+      // Test with non-owned collateral
+    });
+  });
+
+  describe("validateQuantity", () => {
+    it("should accept valid quantity", async () => {
+      // Test with valid quantity
+    });
+
+    it("should reject zero quantity", async () => {
+      // Test with zero quantity
+    });
+
+    it("should reject negative quantity", async () => {
+      // Test with negative quantity
+    });
+  });
+});
+```
+
+#### NFT Manager Tests
+
+```typescript
+describe("NFTManager", () => {
+  describe("lock", () => {
+    it("should lock NFT for escrow", async () => {
+      // Test NFT locking
+    });
+
+    it("should return error for already locked NFT", async () => {
+      // Test with already locked NFT
+    });
+  });
+
+  describe("unlock", () => {
+    it("should unlock NFT after escrow", async () => {
+      // Test NFT unlocking
+    });
+
+    it("should return NFT to original owner", async () => {
+      // Test NFT return
+    });
+  });
+});
+```
+
+### Integration Tests
+
+#### End-to-End NFT Collateral Flow
+
+```typescript
+describe("NFT Collateral Integration", () => {
+  it("should complete full NFT collateral escrow flow", async () => {
+    // 1. Create NFT collateral
+    // 2. Validate ownership
+    // 3. Lock NFT
+    // 4. Create escrow
+    // 5. Release escrow
+    // 6. Unlock NFT
+    // 7. Verify NFT returned to owner
+  });
+
+  it("should handle NFT collateral refund", async () => {
+    // 1. Create NFT collateral escrow
+    // 2. Refund escrow
+    // 3. Verify NFT returned to owner
+  });
+
+  it("should handle multiple NFTs in single escrow", async () => {
+    // 1. Create escrow with multiple NFTs
+    // 2. Verify all NFTs locked
+    // 3. Release escrow
+    // 4. Verify all NFTs returned
+  });
+});
+```
+
+#### Semi-Fungible Collateral Flow
+
+```typescript
+describe("Semi-Fungible Collateral Integration", () => {
+  it("should complete full semi-fungible collateral escrow flow", async () => {
+    // 1. Create semi-fungible collateral
+    // 2. Validate quantity
+    // 3. Lock semi-fungible
+    // 4. Create escrow
+    // 5. Release escrow
+    // 6. Verify units returned
+  });
+
+  it("should handle partial quantity locking", async () => {
+    // 1. Create escrow with partial quantity
+    // 2. Verify only specified units locked
+    // 3. Release escrow
+    // 4. Verify units returned
+  });
+});
+```
+
+### Property-Based Tests
+
+#### Token Standard Detection Properties
+
+```typescript
+// Property 1: Token Standard Detection Accuracy
+// Feature: nft-collateral-support, Property 1: Token Standard Detection Accuracy
+
+property("Token standard detection is accurate", async () => {
+  // Generate random token contract addresses
+  // For each contract, verify correct standard detection
+  // Verify priority logic for multiple standards
+});
+```
+
+#### NFT Collateral Properties
+
+```typescript
+// Property 2: NFT Ownership Validation
+// Feature: nft-collateral-support, Property 2: NFT Ownership Validation
+
+property("NFT ownership validation is accurate", async () => {
+  // Generate random NFTs
+  // For owned NFTs, validation should pass
+  // For non-owned NFTs, validation should fail
+});
+
+// Property 3: NFT Collateral Storage Integrity
+// Feature: nft-collateral-support, Property 3: NFT Collateral Storage Integrity
+
+property("NFT collateral storage is consistent", async () => {
+  // Generate random NFT collateral
+  // Pledge and verify stored values match
+  // Query escrow and verify retrieval
+});
+
+// Property 4: NFT Transfer Prevention During Escrow
+// Feature: nft-collateral-support, Property 4: NFT Transfer Prevention During Escrow
+
+property("NFT transfer is prevented during escrow", async () => {
+  // Generate random NFTs
+  // Pledge and verify transfer is blocked
+  // Release and verify transfer is allowed
+});
+```
+
+#### Semi-Fungible Properties
+
+```typescript
+// Property 5: Semi-Fungible Quantity Validation
+// Feature: nft-collateral-support, Property 5: Semi-Fungible Quantity Validation
+
+property("Semi-fungible quantity validation is accurate", async () => {
+  // Generate random quantities
+  // Valid quantities should pass
+  // Zero/negative quantities should fail
+});
+
+// Property 6: Semi-Fungible Balance Tracking
+// Feature: nft-collateral-support, Property 6: Semi-Fungible Balance Tracking
+
+property("Semi-fungible balance tracking is accurate", async () => {
+  // Generate random semi-fungible tokens
+  // Pledge and verify balance is locked
+  // Release and verify balance is restored
+});
+```
+
+#### Backward Compatibility Properties
+
+```typescript
+// Property 7: Backward Compatibility with Fungible Tokens
+// Feature: nft-collateral-support, Property 7: Backward Compatibility with Fungible Tokens
+
+property("Fungible tokens use existing logic", async () => {
+  // Generate random fungible tokens
+  // Verify fungible token logic is used
+  // Verify NFT validation is not applied
+});
+```
+
+#### Metadata Properties
+
+```typescript
+// Property 9: Metadata Retrieval and Caching
+// Feature: nft-collateral-support, Property 9: Metadata Retrieval and Caching
+
+property("NFT metadata is retrieved and cached", async () => {
+  // Generate random NFTs with metadata
+  // Verify metadata is retrieved
+  // Verify metadata is cached
+  // Verify cached metadata is used
+});
+```
+
+### Test Configuration
+
+```typescript
+// Property-based test configuration
+const PBT_CONFIG = {
+  numRuns: 100, // Minimum 100 iterations per property
+  timeout: 30000, // 30 seconds per test
+  verbose: false,
+};
+
+// Tag format for property tests
+// Feature: nft-collateral-support, Property {number}: {property_text}
+```
+
+### Test Coverage Matrix
+
+| Requirement                     | Unit Test | Integration Test | Property Test |
+| ------------------------------- | --------- | ---------------- | ------------- |
+| 1.1 NFT acceptance              | ✓         | ✓                | ✓             |
+| 1.2 NFT storage                 | ✓         | ✓                | ✓             |
+| 1.3 Transfer prevention         | ✓         | ✓                | ✓             |
+| 1.4 Error handling              | ✓         | ✓                | ✓             |
+| 1.5 Ownership validation        | ✓         | ✓                | ✓             |
+| 2.1 Semi-fungible acceptance    | ✓         | ✓                | ✓             |
+| 2.2 Semi-fungible storage       | ✓         | ✓                | ✓             |
+| 2.3 Transfer prevention         | ✓         | ✓                | ✓             |
+| 2.4 Quantity validation         | ✓         | ✓                | ✓             |
+| 2.5 Ownership validation        | ✓         | ✓                | ✓             |
+| 3.1 Standard detection          | ✓         | ✓                | ✓             |
+| 3.2 NFT interface check         | ✓         | ✓                | ✓             |
+| 3.3 Semi-fungible check         | ✓         | ✓                | ✓             |
+| 3.4 Unknown standard error      | ✓         | ✓                | ✓             |
+| 3.5 Multiple standards priority | ✓         | ✓                | ✓             |
+| 4.1-4.5 Validation              | ✓         | ✓                | ✓             |
+| 5.1-5.5 Backward compatibility  | ✓         | ✓                | ✓             |
+| 6.1-6.5 Interface support       | ✓         | ✓                | ✓             |
+| 7.1-7.5 Error handling          | ✓         | ✓                | ✓             |
+| 8.1-8.5 Release/refund          | ✓         | ✓                | ✓             |
+| 9.1-9.5 Metadata handling       | ✓         | ✓                | ✓             |
+| 10.1-10.5 Gas efficiency        | ✓         | ✓                | ✓             |
+
+## Implementation Notes
+
+### Key Design Decisions
+
+1. **Token Standard Priority**: NFT > Semi-Fungible > Fungible
+   - Rationale: More specific standards should take precedence
+   - Implementation: Priority scores in detection logic
+
+2. **Validation Caching**: Cache validation results for escrow duration
+   - Rationale: Avoid redundant contract calls
+   - Implementation: In-memory cache with timestamp
+
+3. **Metadata Caching**: Cache NFT metadata during escrow
+   - Rationale: Reduce external API calls
+   - Implementation: Cache with escrow ID as key
+
+4. **Batch Operations**: Batch NFT operations when possible
+   - Rationale: Reduce transaction costs
+   - Implementation: Group operations by escrow
+
+5. **Backward Compatibility**: Fungible tokens use existing logic
+   - Rationale: No disruption to existing users
+   - Implementation: Separate code paths with unified interface
+
+### Performance Considerations
+
+1. **Contract Calls**: Minimize RPC calls through caching
+2. **Batching**: Group operations to reduce transaction count
+3. **Parallel Processing**: Validate multiple NFTs in parallel
+4. **Lazy Loading**: Load metadata only when requested
+
+### Security Considerations
+
+1. **Ownership Verification**: Always verify ownership before accepting collateral
+2. **Input Validation**: Validate all user inputs
+3. **Error Handling**: Never leak sensitive information in errors
+4. **Access Control**: Ensure only authorized parties can release collateral
+
+## Next Steps
+
+1. Implement token standard detection logic
+2. Implement NFT manager with lock/unlock operations
+3. Implement semi-fungible manager with balance tracking
+4. Implement unified collateral validator
+5. Update escrow contract to support new collateral types
+6. Write unit tests for each component
+7. Write integration tests for end-to-end flows
+8. Write property-based tests for correctness properties
+9. Update documentation and user guides

--- a/.kiro/specs/nft-collateral-support/requirements.md
+++ b/.kiro/specs/nft-collateral-support/requirements.md
@@ -1,0 +1,139 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds support for NFT (Non-Fungible Tokens) and semi-fungible tokens as collateral in the escrow system. Currently, the contract only supports standard fungible tokens (like USDC) for staking and escrow operations. Artisans may want to stake NFTs, specialized receipt tokens, or wrapped assets as collateral, requiring the system to handle multiple token standards.
+
+## Glossary
+
+- **System**: The Craft Nexus escrow platform that manages collateral and staking operations
+- **NFT**: Non-Fungible Token - a unique digital asset that cannot be interchanged
+- **Semi-Fungible Token**: A token that has both fungible and non-fungible aspects (e.g., multiple units of unique items)
+- **Token Standard**: The technical specification that defines how a token behaves (e.g., Fungible Token, Non-Fungible Token)
+- **Collateral**: Assets pledged by a party to secure a transaction or obligation
+- **Staking**: The process of locking assets as collateral to participate in a system
+- **Token Contract**: The smart contract that implements a specific token standard
+- **Token ID**: A unique identifier for a specific NFT or semi-fungible token unit
+- **Fungible Token**: A token where all units are identical and interchangeable (e.g., USDC)
+
+## Requirements
+
+### Requirement 1: Support NFT Collateral
+
+**User Story:** As an artisan, I want to stake NFTs as collateral, so that I can use my unique digital assets to secure transactions.
+
+#### Acceptance Criteria
+
+1. WHEN an NFT is provided as collateral, THE System SHALL accept it as valid collateral
+2. WHEN an NFT collateral is pledged, THE System SHALL store the Token Contract address and Token ID
+3. WHILE an NFT is pledged as collateral, THE System SHALL prevent its transfer or sale
+4. IF an NFT collateral is invalid or the token contract is not supported, THEN THE System SHALL return an error with a descriptive message
+5. WHERE an NFT is used as collateral, THE System SHALL validate that the user owns the NFT before accepting it
+
+### Requirement 2: Support Semi-Fungible Collateral
+
+**User Story:** As an artisan, I want to stake semi-fungible tokens as collateral, so that I can use assets that have both unique and fungible aspects.
+
+#### Acceptance Criteria
+
+1. WHEN a semi-fungible token is provided as collateral, THE System SHALL accept it as valid collateral
+2. WHEN semi-fungible collateral is pledged, THE System SHALL store the Token Contract address, Token ID, and quantity
+3. WHILE semi-fungible collateral is pledged, THE System SHALL prevent transfer of the pledged units
+4. IF semi-fungible collateral has an invalid quantity (zero or negative), THEN THE System SHALL return an error
+5. WHERE semi-fungible tokens are used as collateral, THE System SHALL validate ownership of the specific token units
+
+### Requirement 3: Token Standard Detection
+
+**User Story:** As the system, I want to detect the token standard of a given contract, so that I can apply the appropriate validation and handling logic.
+
+#### Acceptance Criteria
+
+1. WHEN a token contract address is provided, THE System SHALL query the contract to determine its token standard
+2. WHEN querying a token contract, THE System SHALL check for NFT metadata interfaces (e.g., `nft_metadata`, `nft_core`)
+3. WHEN querying a token contract, THE System SHALL check for semi-fungible interfaces (e.g., `sfungible_token`)
+4. IF the token standard cannot be determined, THEN THE System SHALL return an error indicating the token standard is unknown
+5. WHERE a token contract supports multiple standards, THE System SHALL use the most specific standard available
+
+### Requirement 4: Collateral Validation
+
+**User Story:** As the system, I want to validate collateral before accepting it, so that only valid assets are used in escrow operations.
+
+#### Acceptance Criteria
+
+1. WHEN collateral is submitted, THE System SHALL validate that the user owns the collateral asset
+2. WHEN NFT collateral is submitted, THE System SHALL verify the Token ID exists in the contract
+3. WHEN semi-fungible collateral is submitted, THE System SHALL verify the requested quantity is available
+4. IF collateral validation fails, THEN THE System SHALL return a descriptive error message
+5. WHERE collateral validation is performed, THE System SHALL cache the validation result for the duration of the escrow creation
+
+### Requirement 5: Backward Compatibility with Fungible Tokens
+
+**User Story:** As an existing user, I want the system to continue supporting standard fungible tokens, so that my current workflows are not disrupted.
+
+#### Acceptance Criteria
+
+1. WHEN a fungible token (e.g., USDC) is used as collateral, THE System SHALL process it using the existing logic
+2. WHEN a fungible token is used as collateral, THE System SHALL NOT apply NFT-specific validation
+3. WHERE a token contract is a standard fungible token, THE System SHALL treat it as fungible regardless of other interfaces
+4. IF a token contract supports both fungible and NFT interfaces, THEN THE System SHALL default to fungible handling unless explicitly specified otherwise
+5. WHERE backward compatibility is required, THE System SHALL maintain the same error messages and behavior as before
+
+### Requirement 6: Token Contract Interface Support
+
+**User Story:** As the system, I want to support common token contract interfaces, so that I can work with a wide range of token standards.
+
+#### Acceptance Criteria
+
+1. WHEN a token contract implements the Fungible Token interface, THE System SHALL support it as a fungible token
+2. WHEN a token contract implements the Non-Fungible Token interface, THE System SHALL support it as an NFT
+3. WHEN a token contract implements the Semi-Fungible Token interface, THE System SHALL support it as a semi-fungible token
+4. WHERE a token contract implements multiple interfaces, THE System SHALL prioritize based on specificity (NFT > semi-fungible > fungible)
+5. IF a token contract implements an unsupported interface, THEN THE System SHALL return an error indicating the interface is not supported
+
+### Requirement 7: Error Handling for Unsupported Tokens
+
+**User Story:** As an artisan, I want clear error messages when using unsupported tokens, so that I can understand why my collateral was rejected.
+
+#### Acceptance Criteria
+
+1. IF an unsupported token standard is used as collateral, THEN THE System SHALL return an error with a descriptive message
+2. IF a token contract is not deployed or does not exist, THEN THE System SHALL return an error indicating the contract is invalid
+3. IF a user attempts to use a token they do not own, THEN THE System SHALL return an error indicating ownership verification failed
+4. WHERE an error occurs during collateral validation, THE System SHALL log the error for debugging purposes
+5. WHEN an error occurs, THE System SHALL provide actionable guidance for the user to resolve the issue
+
+### Requirement 8: Collateral Release and Refund
+
+**User Story:** As an artisan, I want my NFT or semi-fungible collateral to be released when the escrow is completed, so that I retain ownership of my assets.
+
+#### Acceptance Criteria
+
+1. WHEN an escrow with NFT collateral is released, THE System SHALL return the NFT to the original owner
+2. WHEN an escrow with semi-fungible collateral is released, THE System SHALL return the pledged units to the original owner
+3. WHEN an escrow with NFT collateral is refunded, THE System SHALL return the NFT to the pledgor
+4. WHEN an escrow with semi-fungible collateral is refunded, THE System SHALL return the pledged units to the pledgor
+5. IF collateral release fails, THEN THE System SHALL log the error and attempt recovery
+
+### Requirement 9: Metadata Handling for NFTs
+
+**User Story:** As the system, I want to store NFT metadata for reference, so that I can provide additional context about the collateral.
+
+#### Acceptance Criteria
+
+1. WHEN an NFT is used as collateral, THE System SHALL retrieve and store the NFT metadata URI
+2. WHEN NFT metadata is retrieved, THE System SHALL cache it for the duration of the escrow
+3. WHERE NFT metadata is available, THE System SHALL include it in escrow status queries
+4. IF NFT metadata cannot be retrieved, THE System SHALL continue with the escrow using available information
+5. WHEN NFT metadata is requested, THE System SHALL provide it in a standardized format
+
+### Requirement 10: Gas and Transaction Efficiency
+
+**User Story:** As the system, I want to minimize transaction costs for NFT collateral operations, so that users are not burdened with excessive fees.
+
+#### Acceptance Criteria
+
+1. WHEN multiple NFTs are used as collateral in a single escrow, THE System SHALL batch operations where possible
+2. WHEN NFT metadata is cached, THE System SHALL reuse the cached data instead of re-fetching
+3. WHERE a token standard has been validated, THE System SHALL skip redundant validation checks
+4. IF a transaction fails due to insufficient gas, THEN THE System SHALL provide a clear error message with gas requirements
+5. WHEN estimating transaction costs, THE System SHALL account for the additional complexity of NFT operations

--- a/.kiro/specs/nft-collateral-support/tasks.md
+++ b/.kiro/specs/nft-collateral-support/tasks.md
@@ -1,0 +1,208 @@
+# Implementation Plan: NFT and Semi-Fungible Collateral Support
+
+## Overview
+
+This feature extends the Craft Nexus escrow system to support NFT and semi-fungible tokens as collateral. The implementation follows a modular architecture with dedicated components for token standard detection, collateral validation, and token-specific management. All tasks build incrementally from core types to integration.
+
+## Tasks
+
+- [ ] 1. Set up project structure and core types
+  - Create `collateral/` directory structure
+  - Define core TypeScript interfaces and types
+  - Implement token standard enumeration
+  - _Requirements: 1, 2, 3, 5, 6_
+
+- [ ] 2. Implement token standard detection
+  - [ ] 2.1 Create token detector interface and implementation
+    - Implement `detectStandard()` method
+    - Implement `hasInterface()` method
+    - Implement `getAvailableInterfaces()` method
+    - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5_
+  - [ ]\* 2.2 Write property test for token standard detection
+    - **Property 1: Token Standard Detection Accuracy**
+    - **Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 6.4**
+  - [ ] 2.3 Implement interface checking logic
+    - Check for NFT interfaces (nft_metadata, nft_core)
+    - Check for semi-fungible interfaces (sfungible_token)
+    - Check for fungible token interfaces (fungible_token)
+    - _Requirements: 6.1, 6.2, 6.3, 6.4, 6.5_
+
+- [ ] 3. Implement NFT collateral management
+  - [ ] 3.1 Create NFT manager interface
+    - Implement `validateOwnership()` method
+    - Implement `lock()` method
+    - Implement `unlock()` method
+    - _Requirements: 1.1, 1.5, 8.1, 8.3_
+  - [ ] 3.2 Implement NFT ownership validation
+    - Query token contract for owner
+    - Verify user owns the specific NFT
+    - Return descriptive errors
+    - _Requirements: 4.1, 4.2, 4.4, 4.5_
+  - [ ] 3.3 Implement NFT lock/unlock operations
+    - Lock NFT for escrow duration
+    - Unlock NFT after escrow release/refund
+    - Handle transaction errors
+    - _Requirements: 1.3, 8.1, 8.3_
+  - [ ] 3.4 Implement NFT metadata handling
+    - Retrieve NFT metadata URI
+    - Cache metadata during escrow
+    - Include metadata in status queries
+    - _Requirements: 9.1, 9.2, 9.3, 9.4, 9.5_
+  - [ ]\* 3.5 Write property test for NFT ownership validation
+    - **Property 2: NFT Ownership Validation**
+    - **Validates: Requirements 1.1, 1.5**
+  - [ ]\* 3.6 Write property test for NFT storage integrity
+    - **Property 3: NFT Collateral Storage Integrity**
+    - **Validates: Requirements 1.2**
+  - [ ]\* 3.7 Write property test for NFT transfer prevention
+    - **Property 4: NFT Transfer Prevention During Escrow**
+    - **Validates: Requirements 1.3, 8.1, 8.3**
+
+- [ ] 4. Implement semi-fungible collateral management
+  - [ ] 4.1 Create semi-fungible manager interface
+    - Implement `validateOwnership()` method
+    - Implement `lock()` method
+    - Implement `unlock()` method
+    - _Requirements: 2.1, 2.5, 8.2, 8.4_
+  - [ ] 4.2 Implement semi-fungible quantity validation
+    - Verify quantity is non-zero
+    - Verify quantity is available
+    - Return descriptive errors
+    - _Requirements: 2.4, 4.3, 4.4, 4.5_
+  - [ ] 4.3 Implement semi-fungible balance tracking
+    - Lock specific token units
+    - Track pledged quantity
+    - Prevent transfer of locked units
+    - _Requirements: 2.2, 2.3, 6.3, 8.2, 8.4_
+  - [ ]\* 4.4 Write property test for semi-fungible quantity validation
+    - **Property 5: Semi-Fungible Quantity Validation**
+    - **Validates: Requirements 2.4**
+  - [ ]\* 4.5 Write property test for semi-fungible balance tracking
+    - **Property 6: Semi-Fungible Balance Tracking**
+    - **Validates: Requirements 2.2, 2.3**
+
+- [ ] 5. Implement unified collateral validator
+  - [ ] 5.1 Create collateral validator service
+    - Implement unified validation interface
+    - Route to token-specific validators
+    - Cache validation results
+    - _Requirements: 4.1, 4.2, 4.3, 4.4, 4.5_
+  - [ ] 5.2 Implement error handling
+    - Token detection errors
+    - Validation errors
+    - Operation errors
+    - _Requirements: 7.1, 7.2, 7.3, 7.4, 7.5_
+  - [ ]\* 5.3 Write unit tests for collateral validator
+    - Test all validation scenarios
+    - Test error handling
+    - Test caching behavior
+    - _Requirements: 4.1-4.5, 7.1-7.5_
+
+- [ ] 6. Implement unified collateral service
+  - [ ] 6.1 Create unified collateral service
+    - Implement single entry point for all collateral types
+    - Route based on token standard
+    - Handle backward compatibility
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+  - [ ] 6.2 Implement backward compatibility layer
+    - Maintain existing fungible token logic
+    - Ensure same error messages
+    - No NFT-specific validation for fungible tokens
+    - _Requirements: 5.1, 5.2, 5.3, 5.4, 5.5_
+  - [ ]\* 6.3 Write property test for backward compatibility
+    - **Property 7: Backward Compatibility with Fungible Tokens**
+    - **Validates: Requirements 5.1, 5.2, 5.3, 5.4, 5.5**
+
+- [ ] 7. Update escrow contract for new collateral types
+  - [ ] 7.1 Update collateral storage structure
+    - Add NFT collateral variant
+    - Add semi-fungible collateral variant
+    - Update enum definitions
+    - _Requirements: 1.2, 2.2, 8.1, 8.2, 8.3, 8.4_
+  - [ ] 7.2 Update release/refund logic
+    - Handle NFT release
+    - Handle semi-fungible release
+    - Handle fungible release (existing)
+    - _Requirements: 8.1, 8.2, 8.3, 8.4, 8.5_
+  - [ ] 7.3 Update escrow status queries
+    - Include collateral type in responses
+    - Include NFT metadata when available
+    - Include semi-fungible quantity
+    - _Requirements: 9.3, 10.3_
+  - [ ]\* 7.4 Write integration tests for escrow contract updates
+    - Test NFT collateral escrow flow
+    - Test semi-fungible collateral escrow flow
+    - Test refund flows
+    - _Requirements: 8.1-8.5_
+
+- [ ] 8. Implement gas optimization
+  - [ ] 8.1 Implement metadata caching
+    - Cache NFT metadata during escrow
+    - Reuse cached metadata
+    - Invalidate on escrow completion
+    - _Requirements: 10.2, 10.3_
+  - [ ] 8.2 Implement batch operations
+    - Batch NFT lock operations
+    - Batch NFT unlock operations
+    - Minimize transaction count
+    - _Requirements: 10.1, 10.3, 10.5_
+  - [ ] 8.3 Implement validation caching
+    - Cache validation results
+    - Skip redundant checks
+    - Include timestamp for freshness
+    - _Requirements: 10.3, 10.4_
+  - [ ]\* 8.4 Write property test for gas efficiency
+    - **Property 10: Gas Efficiency Through Batching**
+    - **Validates: Requirements 10.1, 10.2, 10.3**
+
+- [ ] 9. Integration tests
+  - [ ] 9.1 Write end-to-end NFT collateral flow test
+    - Create NFT collateral
+    - Validate ownership
+    - Lock NFT
+    - Create escrow
+    - Release escrow
+    - Unlock NFT
+    - Verify NFT returned
+    - _Requirements: 1.1-1.5, 8.1, 8.3, 9.1-9.5_
+  - [ ] 9.2 Write end-to-end semi-fungible collateral flow test
+    - Create semi-fungible collateral
+    - Validate quantity
+    - Lock semi-fungible
+    - Create escrow
+    - Release escrow
+    - Unlock semi-fungible
+    - Verify units returned
+    - _Requirements: 2.1-2.5, 8.2, 8.4_
+  - [ ] 9.3 Write multi-token escrow test
+    - Create escrow with multiple NFTs
+    - Verify all NFTs locked
+    - Release escrow
+    - Verify all NFTs returned
+    - _Requirements: 10.1_
+  - [ ] 9.4 Write error handling integration test
+    - Test invalid NFT
+    - Test non-owned collateral
+    - Test zero quantity
+    - Test unsupported token
+    - _Requirements: 7.1-7.5_
+
+- [ ] 10. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 11. Final checkpoint - Verify requirements coverage
+  - Verify all 10 requirements are covered by implementation
+  - Verify all acceptance criteria are tested
+  - Verify error messages are descriptive and actionable
+  - Ensure gas efficiency optimizations are working
+  - Ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties
+- Unit tests validate specific examples and edge cases
+- Integration tests validate end-to-end flows
+- TypeScript is used as the implementation language based on the design document

--- a/.kiro/specs/partial-refund-proposal-race-condition/.config.kiro
+++ b/.kiro/specs/partial-refund-proposal-race-condition/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "5e3e2c40-6dc9-444b-a31c-74f417def4ff", "workflowType": "requirements-first", "specType": "bugfix"}

--- a/.kiro/specs/partial-refund-proposal-race-condition/bugfix.md
+++ b/.kiro/specs/partial-refund-proposal-race-condition/bugfix.md
@@ -1,0 +1,35 @@
+# Bugfix Requirements Document
+
+## Introduction
+
+This bugfix addresses a race condition in the `propose_partial_refund` function that allows creating settlement proposals for disputed escrows. When both buyer and seller submit proposals in the same ledger block or rapidly consecutively, they might overwrite each other's proposals without knowing, leading to unpredictable negotiation flows and potential loss of proposal state.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+1.1 WHEN both buyer and seller submit partial refund proposals in the same ledger block THEN the system allows overwriting without notification, causing race conditions in proposal acceptance
+
+1.2 WHEN a party submits a proposal and the counterparty submits another proposal before the first is accepted OR cancelled THEN the system overwrites the first proposal without explicit cancellation from the proposing party
+
+1.3 WHEN a proposal exists and no mechanism is available for the proposing party to withdraw it THEN the proposal remains active indefinitely, blocking new proposals
+
+### Expected Behavior (Correct)
+
+2.1 WHEN a party submits a partial refund proposal THEN the system SHALL assign a unique proposal ID and store the proposal with metadata including the proposer and timestamp
+
+2.2 WHEN a proposal exists and the counterparty attempts to submit a new proposal THEN the system SHALL require explicit cancellation of the existing proposal before accepting the new one
+
+2.3 WHEN the proposing party wishes to withdraw their proposal BEFORE it is accepted THEN the system SHALL allow explicit cancellation with a dedicated function
+
+2.4 WHEN both proposals are submitted in the same ledger block THEN the system SHALL use a deterministic tie-breaking mechanism (e.g., lexicographic order of proposer addresses) to ensure predictable ordering
+
+### Unchanged Behavior (Regression Prevention)
+
+3.1 WHEN a proposal is accepted by the counterparty THEN the system SHALL CONTINUE TO distribute funds according to the proposal amount and platform fee
+
+3.2 WHEN a proposal is not accepted within the escrow's lifetime THEN the system SHALL CONTINUE TO allow the proposal to be accepted until the escrow is resolved
+
+3.3 WHEN only one party submits a proposal THEN the system SHALL CONTINUE TO allow the counterparty to accept it for negotiation
+
+3.4 WHEN a proposal is submitted by an unauthorized party (neither buyer nor seller) THEN the system SHALL CONTINUE TO reject the proposal with an unauthorized error

--- a/.kiro/specs/partial-refund-proposal-race-condition/design.md
+++ b/.kiro/specs/partial-refund-proposal-race-condition/design.md
@@ -1,0 +1,458 @@
+# Partial Refund Proposal Race Condition Bugfix Design
+
+## Overview
+
+This bugfix addresses a race condition in the `propose_partial_refund` function that allows creating settlement proposals for disputed escrows. When both buyer and seller submit proposals in the same ledger block or rapidly consecutively, they might overwrite each other's proposals without knowing, leading to unpredictable negotiation flows and potential loss of proposal state.
+
+The fix introduces:
+
+- Unique proposal IDs to track individual proposals
+- Proposal locks to prevent overwrites without explicit cancellation
+- A dedicated `cancel_proposal` function for proposers to withdraw their proposals
+- Deterministic tie-breaking for same-block proposals using lexicographic order of proposer addresses
+
+## Glossary
+
+- **Bug_Condition (C)**: The condition that triggers the race condition - when both buyer and seller submit proposals in the same ledger block without tracking, causing overwrites
+- **Property (P)**: The desired behavior when proposals are submitted - each proposal gets a unique ID, proposals cannot be overwritten without explicit cancellation, and tie-breaking is deterministic
+- **Preservation**: Existing negotiation flows that must remain unchanged - proposal acceptance, fund distribution, and escrow status transitions
+- **proposal_id**: A unique identifier generated for each proposal (hash of proposer + timestamp + nonce)
+- **proposal_lock**: A mechanism that prevents new proposals from overwriting existing ones without explicit cancellation
+- **active_proposal**: A proposal that has been submitted but not yet accepted, cancelled, or expired
+- **proposer_address**: The Stellar address of the party who submitted the proposal
+- **proposal_timestamp**: The ledger timestamp when the proposal was submitted
+
+## Bug Details
+
+### Bug Condition
+
+The race condition manifests when both buyer and seller submit partial refund proposals in the same ledger block or rapidly consecutively. The system allows overwriting without notification, causing:
+
+1. Proposals from one party being silently overwritten by the other party's proposal
+2. No mechanism for proposers to withdraw their proposals before acceptance
+3. No deterministic tie-breaking for same-block proposals
+
+**Formal Specification:**
+
+```
+FUNCTION isBugCondition(input)
+  INPUT: input of type EscrowProposalSubmission
+  OUTPUT: boolean
+
+  RETURN input.proposer IN [escrow.buyer, escrow.seller]
+         AND existingProposalExists(input.order_id)
+         AND NOT isSameProposalId(input, existingProposal)
+         AND NOT isCancellation(input)
+END FUNCTION
+```
+
+### Examples
+
+- **Example 1 - Overwrite Race**: Buyer submits proposal at ledger 1000, seller submits proposal at ledger 1000 (same block). Seller's proposal overwrites buyer's without notification. Expected: Both proposals should be tracked with unique IDs, seller should be required to cancel buyer's proposal first.
+
+- **Example 2 - No Withdrawal**: Buyer submits proposal, seller submits counter-proposal before buyer can accept. Buyer has no way to withdraw their original proposal. Expected: Buyer should be able to call `cancel_proposal` to withdraw their proposal.
+
+- **Example 3 - No Tie-Breaking**: Two proposals submitted in the same block by different parties. System has no deterministic way to order them. Expected: Proposals should be ordered lexicographically by proposer address.
+
+- **Edge Case - Same Proposal**: Buyer submits proposal, then submits identical proposal again. Expected: This should be allowed (idempotent) or rejected with clear error.
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors:**
+
+- When a proposal is accepted by the counterparty, funds SHALL be distributed according to the proposal amount and platform fee
+- When a proposal is not accepted within the escrow's lifetime, the proposal SHALL remain active until the escrow is resolved
+- When only one party submits a proposal, the counterparty SHALL be able to accept it for negotiation
+- When a proposal is submitted by an unauthorized party (neither buyer nor seller), the proposal SHALL be rejected with an unauthorized error
+
+**Scope:**
+All existing negotiation flows and escrow operations should continue to work exactly as before. This fix only adds tracking and locking mechanisms without changing the core negotiation logic.
+
+## Hypothesized Root Cause
+
+Based on the bug description, the most likely issues are:
+
+1. **Missing Proposal Tracking**: The current implementation likely stores only one proposal per escrow without unique identifiers
+   - No proposal_id field in storage
+   - No proposer_address tracking
+   - No timestamp for tie-breaking
+
+2. **No Locking Mechanism**: The system allows proposals to overwrite each other without validation
+   - No check for existing active proposals before accepting new ones
+   - No requirement for explicit cancellation before overwriting
+
+3. **No Cancellation Function**: There is no way for proposers to withdraw their proposals
+   - Missing `cancel_proposal` function
+   - Proposals remain active indefinitely if not accepted
+
+4. **No Deterministic Ordering**: Same-block proposals have no tie-breaking mechanism
+   - No lexicographic ordering by proposer address
+   - No timestamp-based ordering for proposals in different ledgers
+
+## Correctness Properties
+
+Property 1: Bug Condition - Unique Proposal Tracking and Locking
+
+_For any_ escrow where both buyer and seller submit proposals, the fixed implementation SHALL assign unique proposal IDs to each proposal, store them with proposer metadata, and prevent overwrites without explicit cancellation.
+
+**Validates: Requirements 2.1, 2.2**
+
+Property 2: Preservation - Existing Negotiation Flows
+
+_For any_ input that does NOT involve proposal race conditions (single proposals, proposal acceptance, escrow status transitions), the fixed implementation SHALL produce exactly the same behavior as the original implementation, preserving all existing negotiation flows.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4**
+
+## Fix Implementation
+
+### Changes Required
+
+**File**: `craft-nexus/lib/stellar/escrow.ts` and smart contract storage
+
+#### 1. Data Structure Changes
+
+**Add proposal ID field to proposal storage:**
+
+- Add `proposal_id: string` - unique identifier for each proposal
+- Add `proposer_address: string` - Stellar address of the proposing party
+- Add `timestamp: number` - ledger timestamp when proposal was submitted
+- Add `active: boolean` - status field to track if proposal is still active
+
+**Storage Structure (Rust-style pseudocode):**
+
+```rust
+struct Proposal {
+    proposal_id: String,           // Hash of proposer + timestamp + nonce
+    proposer_address: Address,     // Who submitted the proposal
+    amount: i128,                  // Proposal amount in stroops
+    timestamp: u64,                // Ledger timestamp
+    active: bool,                  // Is this proposal still active?
+}
+
+struct Escrow {
+    buyer: Address,
+    seller: Address,
+    token: Address,
+    amount: i128,
+    status: EscrowStatus,
+    created_at: u64,
+    release_window: u64,
+    // New fields for proposal tracking
+    buyer_proposal: Option<Proposal>,
+    seller_proposal: Option<Proposal>,
+}
+```
+
+#### 2. Logic Changes to `propose_partial_refund`
+
+**Add proposal ID generation:**
+
+- Generate unique proposal ID using hash of (proposer_address + timestamp + nonce)
+- Use ledger timestamp for deterministic ordering
+- Add random nonce to prevent hash collisions for same-timestamp proposals
+
+**Add existing proposal check:**
+
+- Before accepting a new proposal, check if proposer already has an active proposal
+- If proposer has active proposal, require explicit cancellation first
+- Return error if attempting to overwrite without cancellation
+
+**Pseudocode:**
+
+```rust
+FUNCTION propose_partial_refund(order_id: u32, proposer: Address, amount: i128) -> Result<(), String>
+  // Load escrow
+  escrow := load_escrow(order_id)
+
+  // Validate proposer is buyer or seller
+  IF proposer != escrow.buyer AND proposer != escrow.seller THEN
+    RETURN Error("Unauthorized: only buyer or seller can propose")
+  END IF
+
+  // Check if proposer already has an active proposal
+  IF proposer == escrow.buyer AND escrow.buyer_proposal.is_some() THEN
+    existing := escrow.buyer_proposal.unwrap()
+    IF existing.active THEN
+      RETURN Error("Existing proposal active. Call cancel_proposal first.")
+    END IF
+  END IF
+
+  IF proposer == escrow.seller AND escrow.seller_proposal.is_some() THEN
+    existing := escrow.seller_proposal.unwrap()
+    IF existing.active THEN
+      RETURN Error("Existing proposal active. Call cancel_proposal first.")
+    END IF
+  END IF
+
+  // Generate unique proposal ID
+  timestamp := get_ledger_timestamp()
+  nonce := generate_random_nonce()
+  proposal_id := hash(proposer + timestamp + nonce)
+
+  // Create new proposal
+  new_proposal := Proposal {
+    proposal_id: proposal_id,
+    proposer_address: proposer,
+    amount: amount,
+    timestamp: timestamp,
+    active: true,
+  }
+
+  // Store proposal
+  IF proposer == escrow.buyer THEN
+    escrow.buyer_proposal := Some(new_proposal)
+  ELSE
+    escrow.seller_proposal := Some(new_proposal)
+  END IF
+
+  save_escrow(escrow)
+  RETURN Ok(())
+END FUNCTION
+```
+
+#### 3. New Function: `cancel_proposal`
+
+**Allow proposing party to withdraw their proposal:**
+
+- Validate proposer authorization (only proposer can cancel)
+- Update proposal status to cancelled (active = false)
+- Return success confirmation
+
+**Pseudocode:**
+
+```rust
+FUNCTION cancel_proposal(order_id: u32, proposer: Address) -> Result<(), String>
+  // Load escrow
+  escrow := load_escrow(order_id)
+
+  // Find and cancel proposer's active proposal
+  IF proposer == escrow.buyer AND escrow.buyer_proposal.is_some() THEN
+    proposal := escrow.buyer_proposal.unwrap()
+    IF proposal.proposer_address != proposer THEN
+      RETURN Error("Unauthorized: only proposer can cancel")
+    END IF
+    IF NOT proposal.active THEN
+      RETURN Error("Proposal already cancelled or accepted")
+    END IF
+    proposal.active := false
+    escrow.buyer_proposal := Some(proposal)
+    save_escrow(escrow)
+    RETURN Ok(())
+  END IF
+
+  IF proposer == escrow.seller AND escrow.seller_proposal.is_some() THEN
+    proposal := escrow.seller_proposal.unwrap()
+    IF proposal.proposer_address != proposer THEN
+      RETURN Error("Unauthorized: only proposer can cancel")
+    END IF
+    IF NOT proposal.active THEN
+      RETURN Error("Proposal already cancelled or accepted")
+    END IF
+    proposal.active := false
+    escrow.seller_proposal := Some(proposal)
+    save_escrow(escrow)
+    RETURN Ok(())
+  END IF
+
+  RETURN Error("No active proposal found")
+END FUNCTION
+```
+
+#### 4. Tie-Breaking Mechanism
+
+**For same-block proposals, use lexicographic order of proposer addresses:**
+
+- Proposals are ordered by (timestamp, proposer_address) tuple
+- Lower timestamp wins
+- If same timestamp, lower proposer address (lexicographic) wins
+
+**Pseudocode:**
+
+```rust
+FUNCTION compare_proposals(p1: Proposal, p2: Proposal) -> Ordering
+  // First compare by timestamp
+  IF p1.timestamp < p2.timestamp THEN
+    RETURN Less
+  END IF
+  IF p1.timestamp > p2.timestamp THEN
+    RETURN Greater
+  END IF
+
+  // Same timestamp - use lexicographic order of proposer addresses
+  RETURN compare(p1.proposer_address, p2.proposer_address)
+END FUNCTION
+
+FUNCTION get_winning_proposal(buyer_proposal: Option<Proposal>, seller_proposal: Option<Proposal>) -> Option<Proposal>
+  IF buyer_proposal.is_none() THEN
+    RETURN seller_proposal
+  END IF
+
+  IF seller_proposal.is_none() THEN
+    RETURN buyer_proposal
+  END IF
+
+  // Both exist - compare and return winner
+  IF compare_proposals(buyer_proposal.unwrap(), seller_proposal.unwrap()) == Less THEN
+    RETURN buyer_proposal
+  ELSE
+    RETURN seller_proposal
+  END IF
+END FUNCTION
+```
+
+#### 5. Smart Contract Changes
+
+**Update proposal storage structure:**
+
+- Add `proposal_id`, `proposer_address`, `timestamp`, `active` fields to Proposal struct
+- Add separate fields for buyer_proposal and seller_proposal
+
+**Add cancellation storage field:**
+
+- No additional storage needed - use `active: bool` field
+
+**Update proposal acceptance logic:**
+
+- Before accepting a proposal, check if it's still active
+- If proposal is cancelled (active = false), reject acceptance
+- Use tie-breaking mechanism when both proposals are active
+
+**Pseudocode for acceptance:**
+
+```rust
+FUNCTION accept_proposal(order_id: u32, acceptor: Address) -> Result<(), String>
+  escrow := load_escrow(order_id)
+
+  // Determine which proposal to accept
+  // If acceptor is buyer, accept seller's proposal
+  // If acceptor is seller, accept buyer's proposal
+
+  IF acceptor == escrow.buyer THEN
+    proposal := escrow.seller_proposal
+  ELSE
+    proposal := escrow.buyer_proposal
+  END IF
+
+  // Check proposal exists and is active
+  IF proposal.is_none() THEN
+    RETURN Error("No proposal found")
+  END IF
+
+  IF NOT proposal.unwrap().active THEN
+    RETURN Error("Proposal is no longer active (cancelled or accepted)")
+  END IF
+
+  // Check acceptor is the counterparty
+  expected_proposer := IF acceptor == escrow.buyer THEN escrow.seller ELSE escrow.buyer
+  IF proposal.unwrap().proposer_address != expected_proposer THEN
+    RETURN Error("Proposal not from counterparty")
+  END IF
+
+  // Accept proposal and distribute funds
+  distribute_funds(escrow, proposal.unwrap().amount)
+
+  // Mark proposal as accepted (not just cancelled)
+  proposal.unwrap().active := false
+  save_escrow(escrow)
+
+  RETURN Ok(())
+END FUNCTION
+```
+
+## Testing Strategy
+
+### Validation Approach
+
+The testing strategy follows a two-phase approach: first, surface counterexamples that demonstrate the race condition on unfixed code, then verify the fix works correctly and preserves existing behavior.
+
+### Exploratory Bug Condition Checking
+
+**Goal**: Surface counterexamples that demonstrate the race condition BEFORE implementing the fix. Confirm or refute the root cause analysis. If we refute, we will need to re-hypothesize.
+
+**Test Plan**: Write tests that simulate concurrent proposal submissions and assert that:
+
+1. Proposals are tracked with unique IDs
+2. Overwrites are prevented without explicit cancellation
+3. Tie-breaking is deterministic for same-block proposals
+
+**Test Cases**:
+
+1. **Overwrite Race Test**: Simulate buyer and seller submitting proposals in same block (will fail on unfixed code)
+2. **No Withdrawal Test**: Verify proposer cannot withdraw proposal without cancellation function (will fail on unfixed code)
+3. **No Tie-Breaking Test**: Verify same-block proposals have deterministic ordering (will fail on unfixed code)
+4. **Cancellation Test**: Verify proposer can cancel their own proposal (will fail on unfixed code)
+
+**Expected Counterexamples**:
+
+- Proposals are overwritten without notification
+- No mechanism to withdraw proposals
+- No deterministic ordering for same-block proposals
+- Proposers cannot cancel their proposals
+
+### Fix Checking
+
+**Goal**: Verify that for all inputs where the bug condition holds, the fixed function produces the expected behavior.
+
+**Pseudocode:**
+
+```
+FOR ALL (order_id, proposer, amount) WHERE isBugCondition(submission) DO
+  result := propose_partial_refund_fixed(order_id, proposer, amount)
+  ASSERT proposal_id_is_unique(result.proposal_id)
+  ASSERT proposal_is_locked(result.proposal_id)
+  ASSERT proposer_can_cancel(result.proposal_id)
+END FOR
+```
+
+### Preservation Checking
+
+**Goal**: Verify that for all inputs where the bug condition does NOT hold, the fixed function produces the same result as the original function.
+
+**Pseudocode:**
+
+```
+FOR ALL (order_id, proposer, amount) WHERE NOT isBugCondition(submission) DO
+  ASSERT original_propose(order_id, proposer, amount) = fixed_propose(order_id, proposer, amount)
+  ASSERT original_accept(order_id, acceptor) = fixed_accept(order_id, acceptor)
+END FOR
+```
+
+**Testing Approach**: Property-based testing is recommended for preservation checking because:
+
+- It generates many test cases automatically across the input domain
+- It catches edge cases that manual unit tests might miss
+- It provides strong guarantees that behavior is unchanged for all non-buggy inputs
+
+**Test Plan**: Observe behavior on UNFIXED code first for single proposals and acceptance, then write property-based tests capturing that behavior.
+
+**Test Cases**:
+
+1. **Single Proposal Preservation**: Verify single proposal submission works as before
+2. **Proposal Acceptance Preservation**: Verify proposal acceptance works as before
+3. **Fund Distribution Preservation**: Verify fund distribution works as before
+4. **Escrow Status Preservation**: Verify escrow status transitions work as before
+
+### Unit Tests
+
+- Test proposal ID generation is unique
+- Test existing proposal check prevents overwrites
+- Test cancellation function validates proposer authorization
+- Test tie-breaking mechanism uses lexicographic order
+- Test acceptance logic checks proposal is still active
+
+### Property-Based Tests
+
+- Generate random escrow states and verify proposals are tracked with unique IDs
+- Generate random proposal submission sequences and verify no overwrites occur
+- Generate random proposer addresses and verify tie-breaking is deterministic
+- Generate random negotiation flows and verify preservation of acceptance logic
+
+### Integration Tests
+
+- Test full negotiation flow with multiple proposals
+- Test cancellation and new proposal submission sequence
+- Test same-block proposal race condition resolution
+- Test escrow status transitions with active proposals
+- Test unauthorized proposal rejection

--- a/.kiro/specs/partial-refund-proposal-race-condition/tasks.md
+++ b/.kiro/specs/partial-refund-proposal-race-condition/tasks.md
@@ -1,0 +1,118 @@
+# Implementation Plan
+
+- [ ] 1. Write bug condition exploration test
+  - **Property 1: Bug Condition** - Partial Refund Proposal Race Condition
+  - **CRITICAL**: This test MUST FAIL on unfixed code - failure confirms the race condition exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior - it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate the race condition exists
+  - **Scoped PBT Approach**: For deterministic bugs, scope the property to concrete failing case(s) to ensure reproducibility
+  - Test implementation details from Bug Condition in design
+  - The test assertions should match the Expected Behavior Properties from design
+  - Run test on UNFIXED code
+  - **EXPECTED OUTCOME**: Test FAILS (this is correct - it proves the race condition exists)
+  - Document counterexamples found to understand root cause
+  - Mark task complete when test is written, run, and failure is documented
+  - _Requirements: 1.1, 1.2, 1.3_
+
+- [ ] 2. Write preservation property tests (BEFORE implementing fix)
+  - **Property 2: Preservation** - Existing Negotiation Flows
+  - **IMPORTANT**: Follow observation-first methodology
+  - Observe behavior on UNFIXED code for single proposals and acceptance
+  - Write property-based tests capturing observed behavior patterns from Preservation Requirements
+  - Property-based testing generates many test cases for stronger guarantees
+  - Run tests on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+- [ ] 3. Fix for partial refund proposal race condition
+  - [ ] 3.1 Update smart contract storage structure
+    - Add `proposal_id: string` field to Proposal struct
+    - Add `proposer_address: string` field to Proposal struct
+    - Add `timestamp: number` field to Proposal struct
+    - Add `active: boolean` field to Proposal struct
+    - Update Escrow struct to store separate buyer_proposal and seller_proposal fields
+    - _Bug_Condition: isBugCondition(input) where both buyer and seller submit proposals in same ledger block_
+    - _Expected_Behavior: expectedBehavior(result) from design - unique proposal IDs and locking_
+    - _Preservation: Preservation Requirements from design - existing negotiation flows unchanged_
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4_
+
+  - [ ] 3.2 Implement propose_partial_refund logic
+    - Generate unique proposal ID using hash of (proposer_address + timestamp + nonce)
+    - Check for existing active proposals before allowing new proposals
+    - Require explicit cancellation or proposal ID match
+    - Return error if proposer attempts to overwrite without cancellation
+    - _Bug_Condition: isBugCondition(input) where existingProposalExists(input.order_id) and NOT isSameProposalId(input, existingProposal)_
+    - _Expected_Behavior: expectedBehavior(result) from design - unique proposal tracking and locking_
+    - _Preservation: Preservation Requirements from design - unauthorized proposals still rejected_
+    - _Requirements: 2.1, 2.2, 3.4_
+
+  - [ ] 3.3 Implement cancel_proposal function
+    - Validate proposer authorization (only proposer can cancel their own proposal)
+    - Update proposal status to cancelled (active = false)
+    - Return success confirmation
+    - Return error if proposal not found or already cancelled
+    - _Bug_Condition: isBugCondition(input) where no mechanism exists for proposers to withdraw proposals_
+    - _Expected_Behavior: expectedBehavior(result) from design - proposers can cancel their proposals_
+    - _Preservation: Preservation Requirements from design - existing negotiation flows unchanged_
+    - _Requirements: 2.3, 3.1, 3.2, 3.3_
+
+  - [ ] 3.4 Implement tie-breaking mechanism
+    - Implement deterministic selection using lexicographic order of proposer addresses
+    - Proposals ordered by (timestamp, proposer_address) tuple
+    - Lower timestamp wins; if same timestamp, lower proposer address (lexicographic) wins
+    - _Bug_Condition: isBugCondition(input) where no deterministic tie-breaking exists for same-block proposals_
+    - _Expected_Behavior: expectedBehavior(result) from design - deterministic ordering using lexicographic comparison_
+    - _Preservation: Preservation Requirements from design - existing negotiation flows unchanged_
+    - _Requirements: 2.4, 3.1, 3.2, 3.3_
+
+  - [ ] 3.5 Update acceptance logic
+    - Update proposal acceptance to handle cancelled proposals
+    - Reject acceptance of cancelled proposals (active = false)
+    - Use tie-breaking mechanism when both proposals are active
+    - Validate proposer authorization (only counterparty can accept)
+    - _Bug_Condition: isBugCondition(input) where proposals can be silently overwritten without notification_
+    - _Expected_Behavior: expectedBehavior(result) from design - proposals tracked with unique IDs and cannot be overwritten_
+    - _Preservation: Preservation Requirements from design - fund distribution and escrow status transitions unchanged_
+    - _Requirements: 2.1, 2.2, 3.1, 3.2, 3.3, 3.4_
+
+  - [ ] 3.6 Write unit tests for proposal ID generation
+    - Test proposal ID is unique for different (proposer, timestamp, nonce) combinations
+    - Test proposal ID generation uses hash function correctly
+    - Test proposal ID is deterministic for same inputs
+    - _Requirements: 2.1_
+
+  - [ ] 3.7 Write property-based tests for race condition prevention
+    - Generate random escrow states and verify proposals are tracked with unique IDs
+    - Generate random proposal submission sequences and verify no overwrites occur
+    - Generate random proposer addresses and verify tie-breaking is deterministic
+    - _Requirements: 2.1, 2.2, 2.4_
+
+  - [ ] 3.8 Write integration tests for complete negotiation flow
+    - Test full negotiation flow with multiple proposals
+    - Test cancellation and new proposal submission sequence
+    - Test same-block proposal race condition resolution
+    - Test escrow status transitions with active proposals
+    - Test unauthorized proposal rejection
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 3.1, 3.2, 3.3, 3.4_
+
+  - [ ] 3.9 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** - Partial Refund Proposal Race Condition
+    - **IMPORTANT**: Re-run the SAME test from task 1 - do NOT write a new test
+    - The test from task 1 encodes the expected behavior
+    - When this test passes, it confirms the expected behavior is satisfied
+    - Run bug condition exploration test from step 1
+    - **EXPECTED OUTCOME**: Test PASSES (confirms bug is fixed)
+    - _Requirements: 2.1, 2.2, 2.3, 2.4_
+
+  - [ ] 3.10 Verify preservation tests still pass
+    - **Property 2: Preservation** - Existing Negotiation Flows
+    - **IMPORTANT**: Re-run the SAME tests from task 2 - do NOT write new tests
+    - Run preservation property tests from step 2
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - Confirm all tests still pass after fix (no regressions)
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+- [ ] 4. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.

--- a/.kiro/specs/platform-wallet-validation/.config.kiro
+++ b/.kiro/specs/platform-wallet-validation/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "654e8c78-42e1-45ba-893b-d13a1aa283e6", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/platform-wallet-validation/design.md
+++ b/.kiro/specs/platform-wallet-validation/design.md
@@ -1,0 +1,648 @@
+# Design Document: Platform Wallet Validation
+
+## Overview
+
+This feature adds validation for the platform wallet address to ensure safe fee collection. The platform wallet receives fees from escrow transactions, and if it's configured with an address that cannot receive funds (e.g., uninitialized account or contract that rejects transfers), all fee transfers will fail, potentially causing global escrow release failures.
+
+The validation service will perform three key checks:
+
+1. **Zero-Amount Ping**: Execute a test transaction to verify the address can receive funds
+2. **Account Existence Check**: Verify the address corresponds to an existing account on the Stellar network
+3. **Contract Transfer Check**: For contract addresses, verify the contract has a receive function that accepts payments
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Platform Wallet Validation Service           │
+├─────────────────────────────────────────────────────────────────────┤
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
+│  │  Zero-Amount     │  │  Account         │  │  Contract        │  │
+│  │  Ping Validator  │  │  Existence       │  │  Transfer        │  │
+│  │                  │  │  Validator       │  │  Validator       │  │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘  │
+│                              │                                      │
+│                              ▼                                      │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │                    Validation Orchestrator                     │  │
+│  │  - Coordinates validation sequence                             │  │
+│  │  - Aggregates results and errors                               │  │
+│  │  - Manages timeout and async behavior                          │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+│                              │                                      │
+│                              ▼                                      │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │                    Configuration Manager                       │  │
+│  │  - Initialize validation                                       │  │
+│  │  - Update validation                                           │  │
+│  │  - Persistent storage                                          │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                        External Dependencies                        │
+├─────────────────────────────────────────────────────────────────────┤
+│  ┌──────────────────┐  ┌──────────────────┐  ┌──────────────────┐  │
+│  │  Stellar Horizon │  │  Soroban RPC     │  │  Configuration   │  │
+│  │  API             │  │  API             │  │  Storage         │  │
+│  └──────────────────┘  └──────────────────┘  └──────────────────┘  │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Components and Interfaces
+
+### Validation Service
+
+The core validation service that orchestrates all validation checks.
+
+```typescript
+interface ValidationService {
+  /**
+   * Perform complete validation of a platform wallet address
+   * @param walletAddress - The Stellar address to validate
+   * @param timeoutMs - Optional timeout in milliseconds (default: 5000)
+   * @returns Validation result with status and error details
+   */
+  validateWallet(
+    walletAddress: string,
+    timeoutMs?: number,
+  ): Promise<ValidationResult>;
+
+  /**
+   * Execute zero-amount ping to verify address can receive funds
+   * @param walletAddress - The Stellar address to ping
+   * @returns Ping result with success status
+   */
+  zeroAmountPing(walletAddress: string): Promise<PingResult>;
+
+  /**
+   * Check if the address corresponds to an existing account
+   * @param walletAddress - The Stellar address to check
+   * @returns Account existence result
+   */
+  checkAccountExists(walletAddress: string): Promise<AccountCheckResult>;
+
+  /**
+   * Check if a contract address can receive transfers
+   * @param walletAddress - The contract address to check
+   * @returns Contract transfer capability result
+   */
+  checkContractTransfers(walletAddress: string): Promise<ContractCheckResult>;
+}
+```
+
+### Configuration Manager
+
+Manages platform wallet configuration with validation integration.
+
+```typescript
+interface ConfigurationManager {
+  /**
+   * Initialize the platform wallet with validation
+   * @param walletAddress - The initial wallet address
+   * @returns Initialization result
+   */
+  initializeWallet(walletAddress: string): Promise<InitializationResult>;
+
+  /**
+   * Update the platform wallet with validation
+   * @param newWalletAddress - The new wallet address
+   * @returns Update result
+   */
+  updateWallet(newWalletAddress: string): Promise<UpdateResult>;
+
+  /**
+   * Get current platform wallet configuration
+   * @returns Current configuration
+   */
+  getWalletConfig(): Promise<WalletConfig>;
+
+  /**
+   * Check if current wallet is valid
+   * @returns Validation status
+   */
+  isWalletValid(): boolean;
+}
+```
+
+### Data Structures
+
+#### Validation Result
+
+```typescript
+interface ValidationResult {
+  status: "valid" | "invalid" | "timeout" | "error";
+  isValid: boolean;
+  errors: ValidationError[];
+  timestamp: number;
+  validationDurationMs: number;
+}
+
+interface ValidationError {
+  code: string;
+  message: string;
+  field?: string;
+  details?: Record<string, unknown>;
+}
+```
+
+#### Ping Result
+
+```typescript
+interface PingResult {
+  success: boolean;
+  error?: string;
+  transactionHash?: string;
+}
+```
+
+#### Account Check Result
+
+```typescript
+interface AccountCheckResult {
+  exists: boolean;
+  isUninitialized: boolean;
+  error?: string;
+}
+```
+
+#### Contract Check Result
+
+```typescript
+interface ContractCheckResult {
+  isContract: boolean;
+  canReceiveTransfers: boolean;
+  hasReceiveFunction: boolean;
+  error?: string;
+}
+```
+
+#### Wallet Configuration
+
+```typescript
+interface WalletConfig {
+  address: string;
+  isValid: boolean;
+  lastValidatedAt: number | null;
+  validationStatus: "pending" | "valid" | "invalid" | "unknown";
+  lastError?: string;
+}
+```
+
+## Data Models
+
+### Validation Log Entry
+
+```typescript
+interface ValidationLogEntry {
+  id: string;
+  walletAddress: string;
+  timestamp: number;
+  result: "success" | "failure" | "timeout";
+  errors: ValidationError[];
+  durationMs: number;
+  validationType: "initialize" | "update" | "scheduled" | "on-demand";
+  ipAddress?: string;
+  userId?: string;
+}
+```
+
+### Platform Wallet Configuration
+
+```typescript
+interface PlatformWalletConfig {
+  address: string;
+  isValid: boolean;
+  lastValidatedAt: number | null;
+  validationStatus: "pending" | "valid" | "invalid" | "unknown";
+  lastError?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+```
+
+## Validation Flow
+
+### Complete Validation Sequence
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    Complete Validation Flow                         │
+├─────────────────────────────────────────────────────────────────────┤
+│  1. Input: Wallet Address                                           │
+│  2. Check if address is valid Stellar format                        │
+│  3. Execute zero-amount ping                                        │
+│  4. Check account existence (if not contract)                       │
+│  5. Check contract transfer capability (if contract)                │
+│  6. Aggregate results and determine validity                        │
+│  7. Log validation result                                           │
+│  8. Return validation result                                        │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Validation Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant ConfigManager
+    participant Validator
+    participant ZeroPing
+    participant AccountCheck
+    participant ContractCheck
+    participant Logger
+
+    Client->>ConfigManager: initializeWallet(address)
+    ConfigManager->>Validator: validateWallet(address)
+
+    Validator->>Validator: Validate Stellar format
+    Validator->>ZeroPing: zeroAmountPing(address)
+    ZeroPing->>Stellar: Submit ping transaction
+    Stellar-->>ZeroPing: Transaction result
+    ZeroPing-->>Validator: Ping result
+
+    alt Not a contract
+        Validator->>AccountCheck: checkAccountExists(address)
+        AccountCheck->>Horizon: Load account
+        Horizon-->>AccountCheck: Account data
+        AccountCheck-->>Validator: Account check result
+    else Is a contract
+        Validator->>ContractCheck: checkContractTransfers(address)
+        ContractCheck->>Soroban: Get contract metadata
+        Soroban-->>ContractCheck: Contract info
+        ContractCheck-->>Validator: Contract check result
+    end
+
+    Validator->>Validator: Aggregate results
+    Validator->>Logger: logValidationResult(result)
+    Logger-->>Validator: Log confirmed
+    Validator-->>ConfigManager: Validation result
+
+    alt Valid
+        ConfigManager->>Storage: Store validated config
+        Storage-->>ConfigManager: Stored
+        ConfigManager-->>Client: Success
+    else Invalid
+        ConfigManager-->>Client: Error with details
+    end
+```
+
+## Correctness Properties
+
+_A property is a characteristic or behavior that should hold true across all valid executions of a system-essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees._
+
+### Property 1: Validation determines address validity correctly
+
+_For any_ valid Stellar address that can receive funds, the validation service SHALL return a valid status with no errors. _For any_ invalid Stellar address (uninitialized account, contract that rejects transfers, etc.), the validation service SHALL return an invalid status with appropriate error messages.
+
+**Validates: Requirements 1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3**
+
+### Property 2: Validation preserves existing configuration on failure
+
+_For any_ platform wallet configuration, when a new address validation fails, the existing wallet address SHALL remain unchanged and the existing configuration SHALL be preserved.
+
+**Validates: Requirements 1.3, 2.2, 6.3**
+
+### Property 3: Validation logs all attempts for audit trail
+
+_For any_ validation attempt (successful or failed), the validation service SHALL create a log entry with the wallet address, timestamp, result, and any error details.
+
+**Validates: Requirements 6.2**
+
+### Property 4: Validation completes within timeout
+
+_For any_ validation request with a specified timeout, the validation service SHALL complete within that timeout or return a timeout error.
+
+**Validates: Requirements 8.1, 8.3**
+
+### Property 5: Zero-amount ping verifies fund receipt capability
+
+_For any_ Stellar address, executing a zero-amount ping transaction that succeeds indicates the address can receive funds. A failed ping transaction indicates the address cannot receive funds.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+### Property 6: Account existence check detects uninitialized accounts
+
+_For any_ Stellar address, checking account existence on the Stellar network correctly identifies whether the account is initialized. Non-existent accounts are identified as uninitialized.
+
+**Validates: Requirements 4.1, 4.2, 4.3**
+
+### Property 7: Contract transfer check verifies receive function
+
+_For any_ contract address, checking contract transfer capability correctly identifies whether the contract has a receive function that accepts payments.
+
+**Validates: Requirements 5.1, 5.2, 5.3**
+
+### Property 8: Escrow operations check wallet validity
+
+_For any_ escrow transaction processing, the payment service SHALL check that the platform wallet is configured and valid before attempting commission transfers.
+
+**Validates: Requirements 7.1, 7.2, 7.3**
+
+## Error Handling
+
+### Error Codes
+
+```typescript
+enum ValidationErrorCode {
+  INVALID_FORMAT = "INVALID_FORMAT",
+  PING_FAILED = "PING_FAILED",
+  ACCOUNT_NOT_FOUND = "ACCOUNT_NOT_FOUND",
+  CONTRACT_REJECTS_TRANSFERS = "CONTRACT_REJECTS_TRANSFERS",
+  NO_RECEIVE_FUNCTION = "NO_RECEIVE_FUNCTION",
+  TIMEOUT = "TIMEOUT",
+  NETWORK_ERROR = "NETWORK_ERROR",
+  CONFIGURATION_ERROR = "CONFIGURATION_ERROR",
+}
+```
+
+### Error Handling Strategy
+
+1. **Format Validation**: Reject addresses that don't match Stellar address format
+2. **Ping Failures**: Return descriptive errors for ping transaction failures
+3. **Account Not Found**: Return specific error for uninitialized accounts
+4. **Contract Issues**: Return specific errors for contracts that reject transfers
+5. **Timeouts**: Return timeout errors with duration information
+6. **Network Errors**: Return network errors with retry guidance
+7. **Configuration Errors**: Return configuration errors for missing dependencies
+
+### Error Response Format
+
+```typescript
+interface ErrorResponse {
+  success: false;
+  error: {
+    code: ValidationErrorCode;
+    message: string;
+    details?: Record<string, unknown>;
+    timestamp: number;
+  };
+}
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+#### Validation Service Tests
+
+```typescript
+describe("ValidationService", () => {
+  describe("zeroAmountPing", () => {
+    it("should succeed for valid address", async () => {
+      // Test that valid addresses pass ping
+    });
+
+    it("should fail for uninitialized account", async () => {
+      // Test that uninitialized accounts fail ping
+    });
+
+    it("should fail for contract that rejects transfers", async () => {
+      // Test that contracts rejecting transfers fail ping
+    });
+
+    it("should timeout for unresponsive addresses", async () => {
+      // Test timeout behavior
+    });
+  });
+
+  describe("checkAccountExists", () => {
+    it("should return true for existing account", async () => {
+      // Test existing account detection
+    });
+
+    it("should return false for non-existent account", async () => {
+      // Test non-existent account detection
+    });
+  });
+
+  describe("checkContractTransfers", () => {
+    it("should return true for contract with receive function", async () => {
+      // Test contract with receive function
+    });
+
+    it("should return false for contract without receive function", async () => {
+      // Test contract without receive function
+    });
+
+    it("should return false for contract that rejects transfers", async () => {
+      // Test contract rejecting transfers
+    });
+  });
+
+  describe("validateWallet", () => {
+    it("should return valid for fully valid address", async () => {
+      // Test complete validation for valid address
+    });
+
+    it("should return invalid with errors for invalid address", async () => {
+      // Test complete validation for invalid address
+    });
+
+    it("should aggregate multiple errors correctly", async () => {
+      // Test error aggregation
+    });
+  });
+});
+```
+
+#### Configuration Manager Tests
+
+```typescript
+describe("ConfigurationManager", () => {
+  describe("initializeWallet", () => {
+    it("should initialize with valid address", async () => {
+      // Test successful initialization
+    });
+
+    it("should reject invalid address", async () => {
+      // Test rejection of invalid address
+    });
+
+    it("should preserve existing config on failure", async () => {
+      // Test config preservation on failure
+    });
+  });
+
+  describe("updateWallet", () => {
+    it("should update with valid address", async () => {
+      // Test successful update
+    });
+
+    it("should reject invalid address", async () => {
+      // Test rejection of invalid address
+    });
+
+    it("should preserve existing config on failure", async () => {
+      // Test config preservation on failure
+    });
+  });
+});
+```
+
+### Integration Tests
+
+```typescript
+describe("Integration Tests", () => {
+  describe("Complete Validation Flow", () => {
+    it("should validate a real Stellar address", async () => {
+      // Test with real Stellar address on testnet
+    });
+
+    it("should detect uninitialized account", async () => {
+      // Test with known uninitialized address
+    });
+
+    it("should detect contract that rejects transfers", async () => {
+      // Test with known contract that rejects transfers
+    });
+  });
+
+  describe("Escrow Integration", () => {
+    it("should check wallet validity before commission transfer", async () => {
+      // Test escrow commission flow with wallet validation
+    });
+
+    it("should log warning for invalid wallet", async () => {
+      // Test warning logging for invalid wallet
+    });
+  });
+});
+```
+
+### Property-Based Tests
+
+```typescript
+// Test Property 1: Validation determines address validity correctly
+property(
+  "validation determines address validity correctly",
+  {
+    generators: [stellarAddressGenerator, validationTypeGenerator],
+    runs: 100,
+  },
+  async (address, validationType) => {
+    const result = await validateWallet(address);
+
+    if (isValidAddress(address)) {
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    } else {
+      expect(result.isValid).toBe(false);
+      expect(result.errors).not.toHaveLength(0);
+    }
+  },
+);
+
+// Test Property 2: Validation preserves existing configuration on failure
+property(
+  "validation preserves existing configuration on failure",
+  {
+    generators: [walletConfigGenerator, invalidAddressGenerator],
+    runs: 100,
+  },
+  async (existingConfig, invalidAddress) => {
+    const result = await updateWallet(invalidAddress);
+
+    expect(result.isValid).toBe(false);
+    expect(result.config.address).toBe(existingConfig.address);
+  },
+);
+
+// Test Property 3: Validation logs all attempts for audit trail
+property(
+  "validation logs all attempts for audit trail",
+  {
+    generators: [stellarAddressGenerator],
+    runs: 100,
+  },
+  async (address) => {
+    await validateWallet(address);
+
+    const logs = await getValidationLogs(address);
+    expect(logs).not.toHaveLength(0);
+    expect(logs[0].walletAddress).toBe(address);
+  },
+);
+
+// Test Property 4: Validation completes within timeout
+property(
+  "validation completes within timeout",
+  {
+    generators: [stellarAddressGenerator, timeoutGenerator],
+    runs: 100,
+  },
+  async (address, timeout) => {
+    const startTime = Date.now();
+    const result = await validateWallet(address, timeout);
+    const duration = Date.now() - startTime;
+
+    expect(duration).toBeLessThanOrEqual(timeout + 1000); // Allow 1s buffer
+  },
+);
+```
+
+### Edge Cases
+
+1. **Uninitialized Accounts**: Test with addresses that exist on chain but have no balance
+2. **Contract Rejections**: Test with contracts that explicitly reject transfers
+3. **Timeout Scenarios**: Test with very short timeouts to verify timeout handling
+4. **Network Failures**: Test with mocked network failures
+5. **Invalid Address Formats**: Test with malformed Stellar addresses
+6. **Empty Address**: Test with empty string address
+7. **Null/Undefined**: Test with null or undefined inputs
+8. **Very Long Addresses**: Test with addresses exceeding normal length
+
+### Test Configuration
+
+- **Unit Tests**: 100+ iterations for property-based tests
+- **Integration Tests**: 1-3 representative examples per scenario
+- **Timeout**: 5 seconds maximum for validation
+- **Mocking**: Use Jest mocks for external dependencies
+- **Test Network**: Use Stellar testnet for integration tests
+
+## Implementation Notes
+
+### Key Design Decisions
+
+1. **Sequential Validation**: Validation checks run sequentially to provide clear error messages and avoid race conditions
+2. **Timeout Protection**: All validation operations have a configurable timeout (default 5 seconds)
+3. **Error Aggregation**: Multiple validation errors are aggregated for comprehensive error reporting
+4. **Async Support**: Validation can run asynchronously to avoid blocking configuration
+5. **Logging**: All validation attempts are logged for audit and debugging purposes
+
+### Performance Considerations
+
+1. **Parallel Execution**: Account existence and contract checks could run in parallel for performance
+2. **Caching**: Validation results could be cached for a short period
+3. **Background Validation**: Validation could run in background after configuration
+4. **Timeout Management**: Each validation step has its own timeout to prevent cascading delays
+
+### Security Considerations
+
+1. **Input Validation**: All inputs are validated for Stellar address format
+2. **Error Sanitization**: Error messages are sanitized to prevent information leakage
+3. **Rate Limiting**: Validation requests could be rate-limited to prevent abuse
+4. **Audit Trail**: All validation attempts are logged for security auditing
+
+## Dependencies
+
+### External Dependencies
+
+1. **Stellar Horizon API**: For account existence checks
+2. **Soroban RPC API**: For contract metadata and transfer capability checks
+3. **Stellar SDK**: For transaction building and address validation
+
+### Internal Dependencies
+
+1. **Configuration Service**: For storing and retrieving wallet configuration
+2. **Logging Service**: For validation logging
+3. **Wallet Service**: For wallet connection and transaction signing
+
+## Deployment Considerations
+
+1. **Environment Variables**: Configure Stellar network endpoints
+2. **API Rate Limits**: Monitor and handle API rate limits
+3. **Network Connectivity**: Ensure reliable network connectivity to Stellar nodes
+4. **Backup Validation**: Consider backup validation methods for critical operations
+5. **Monitoring**: Implement monitoring for validation failures and timeouts

--- a/.kiro/specs/platform-wallet-validation/requirements.md
+++ b/.kiro/specs/platform-wallet-validation/requirements.md
@@ -1,0 +1,96 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds validation for the platform wallet address to ensure safe fee collection. The platform wallet receives fees from escrow transactions, and if it's configured with an address that cannot receive funds (e.g., uninitialized account or contract that rejects transfers), all fee transfers will fail, potentially causing global escrow release failures.
+
+## Glossary
+
+- **Platform Wallet**: The Stellar account address that receives platform commission fees from escrow transactions
+- **Platform Commission**: The percentage of each transaction (currently 5%) that the platform collects as fees
+- **Initialize**: The process of setting up the platform wallet configuration for the first time
+- **Configuration Update**: The process of modifying the platform wallet address after initial setup
+- **Zero-Amount Ping**: A test transaction with zero value to verify an address can receive funds
+- **Signature Validation Check**: A cryptographic verification that an address is valid and controlled by an account
+
+## Requirements
+
+### Requirement 1: Validate Platform Wallet During Initialization
+
+**User Story:** As a system administrator, I want to validate the platform wallet address during initialization, so that the platform can safely collect fees from day one.
+
+#### Acceptance Criteria
+
+1. WHEN the platform wallet is initialized for the first time, THE Configuration Manager SHALL validate that the address can receive funds
+2. IF the validation fails, THEN THE Configuration Manager SHALL return an error and prevent initialization
+3. WHERE the validation succeeds, THE Configuration Manager SHALL store the validated address in persistent configuration
+
+### Requirement 2: Validate Platform Wallet During Configuration Updates
+
+**User Story:** As a system administrator, I want to validate the platform wallet address during configuration updates, so that future fee transfers won't fail due to invalid addresses.
+
+#### Acceptance Criteria
+
+1. WHEN a configuration update is requested to change the platform wallet address, THE Configuration Manager SHALL validate the new address
+2. IF the validation fails, THEN THE Configuration Manager SHALL return an error and retain the existing valid address
+3. WHERE the validation succeeds, THE Configuration Manager SHALL update the platform wallet address to the new validated address
+
+### Requirement 3: Validation Method - Zero-Amount Ping
+
+**User Story:** As a developer, I want to use a zero-amount ping to validate the platform wallet, so that we can verify the address is valid and can receive funds without risking real assets.
+
+#### Acceptance Criteria
+
+1. WHERE validation is performed, THE Validator SHALL execute a zero-amount ping transaction to the platform wallet address
+2. WHEN the zero-amount ping succeeds, THE Validator SHALL consider the address valid for receiving funds
+3. IF the zero-amount ping fails, THEN THE Validator SHALL return a descriptive error indicating why validation failed
+
+### Requirement 4: Validation Method - Account Existence Check
+
+**User Story:** As a developer, I want to verify the platform wallet account exists on the Stellar network, so that we can detect uninitialized accounts before they cause fee collection failures.
+
+#### Acceptance Criteria
+
+1. WHERE validation is performed, THE Validator SHALL check if the platform wallet address corresponds to an existing account on the Stellar network
+2. WHEN the account exists, THE Validator SHALL proceed with additional validation checks
+3. IF the account does not exist, THEN THE Validator SHALL return an error indicating the account is uninitialized
+
+### Requirement 5: Validation Method - Contract Transfer Check
+
+**User Story:** As a developer, I want to verify that contract addresses can receive transfers, so that we don't configure a wallet that rejects incoming payments.
+
+#### Acceptance Criteria
+
+1. WHERE the platform wallet address is a contract, THE Validator SHALL verify the contract has a receive function that accepts payments
+2. WHEN the contract can receive payments, THE Validator SHALL consider the address valid
+3. IF the contract rejects transfers or has no receive function, THEN THE Validator SHALL return an error indicating the contract cannot receive funds
+
+### Requirement 6: Error Handling and Logging
+
+**User Story:** As a system operator, I want clear error messages when validation fails, so that I can quickly identify and fix configuration issues.
+
+#### Acceptance Criteria
+
+1. IF validation fails for any reason, THEN THE Validator SHALL return a descriptive error message explaining the specific failure reason
+2. WHEN validation is performed, THE Validator SHALL log the validation attempt and result for audit purposes
+3. WHERE validation fails, THE Validator SHALL preserve the existing valid platform wallet address unchanged
+
+### Requirement 7: Validation Integration with Escrow Operations
+
+**User Story:** As a developer, I want validation to be integrated with escrow operations, so that fee collection failures are prevented at the configuration level.
+
+#### Acceptance Criteria
+
+1. WHEN an escrow transaction is processed, THE Payment Service SHALL check that the platform wallet is configured and valid
+2. IF the platform wallet is not configured or validation fails, THEN THE Payment Service SHALL log a warning but continue processing the escrow
+3. WHERE platform commission is calculated, THE Payment Service SHALL attempt to transfer commission to the validated platform wallet address
+
+### Requirement 8: Validation Performance and Efficiency
+
+**User Story:** As a developer, I want validation to be efficient and not block critical operations, so that the system remains responsive during configuration changes.
+
+#### Acceptance Criteria
+
+1. WHEN configuration initialization or update is performed, THE Validator SHALL complete validation within 5 seconds
+2. WHERE validation is performed asynchronously, THE System SHALL allow configuration to proceed while validation completes in the background
+3. IF validation takes longer than expected, THEN THE System SHALL timeout and return an error

--- a/.kiro/specs/platform-wallet-validation/tasks.md
+++ b/.kiro/specs/platform-wallet-validation/tasks.md
@@ -1,0 +1,256 @@
+# Implementation Plan: Platform Wallet Validation
+
+## Overview
+
+This feature adds validation for the platform wallet address to ensure safe fee collection. The validation service performs three key checks: zero-amount ping, account existence check, and contract transfer check. This document breaks down the implementation into discrete, actionable steps.
+
+## Tasks
+
+- [ ] 1. Set up project structure and core interfaces
+  - Create directory structure for validation service
+  - Define core TypeScript interfaces and types
+  - Set up testing framework and configuration
+  - _Requirements: 1, 2, 3, 4, 5, 6, 7, 8_
+
+- [ ] 2. Implement data structures
+  - [ ] 2.1 Create validation result structure
+    - Implement `ValidationResult`, `ValidationError` interfaces
+    - Implement `PingResult` interface
+    - Implement `AccountCheckResult` interface
+    - Implement `ContractCheckResult` interface
+    - Implement `WalletConfig` interface
+    - Implement `ValidationLogEntry` interface
+    - _Requirements: 1, 2, 3, 4, 5, 6, 7, 8_
+
+  - [ ]\* 2.2 Write unit tests for data structures
+    - Test interface instantiation and validation
+    - Test edge cases for each data structure
+    - _Requirements: 1, 2, 3, 4, 5, 6, 7, 8_
+
+- [ ] 3. Implement validation service
+  - [ ] 3.1 Implement zero-amount ping function
+    - Create `zeroAmountPing` function in validation service
+    - Build zero-value transaction to test address
+    - Handle transaction success/failure cases
+    - Return `PingResult` with appropriate status
+    - _Requirements: 3.1, 3.2, 3.3_
+
+  - [ ]\* 3.2 Write property test for zero-amount ping
+    - **Property 5: Zero-amount ping verifies fund receipt capability**
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+    - Test that successful ping indicates fund receipt capability
+    - Test that failed ping indicates inability to receive funds
+
+  - [ ] 3.3 Implement account existence check function
+    - Create `checkAccountExists` function in validation service
+    - Query Stellar Horizon API for account existence
+    - Distinguish between existing and uninitialized accounts
+    - Return `AccountCheckResult` with existence status
+    - _Requirements: 4.1, 4.2, 4.3_
+
+  - [ ]\* 3.4 Write unit tests for account existence check
+    - Test existing account detection
+    - Test uninitialized account detection
+    - Test error handling for network failures
+    - _Requirements: 4.1, 4.2, 4.3_
+
+  - [ ] 3.5 Implement contract transfer check function
+    - Create `checkContractTransfers` function in validation service
+    - Query Soroban RPC for contract metadata
+    - Check for receive function that accepts payments
+    - Return `ContractCheckResult` with transfer capability
+    - _Requirements: 5.1, 5.2, 5.3_
+
+  - [ ]\* 3.6 Write unit tests for contract transfer check
+    - Test contract with receive function
+    - Test contract without receive function
+    - Test contract that rejects transfers
+    - _Requirements: 5.1, 5.2, 5.3_
+
+  - [ ] 3.7 Implement validation orchestrator
+    - Create `validateWallet` function in validation service
+    - Coordinate sequential validation checks
+    - Aggregate results and errors from all checks
+    - Implement timeout handling (default 5 seconds)
+    - Return comprehensive `ValidationResult`
+    - _Requirements: 1, 2, 3, 4, 5, 6, 8.1, 8.3_
+
+  - [ ]\* 3.8 Write property test for validation orchestrator
+    - **Property 1: Validation determines address validity correctly**
+    - **Validates: Requirements 1.1, 1.2, 2.1, 2.2, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3**
+    - Test valid addresses return valid status
+    - Test invalid addresses return invalid status with errors
+
+  - [ ]\* 3.9 Write property test for timeout handling
+    - **Property 4: Validation completes within timeout**
+    - **Validates: Requirements 8.1, 8.3**
+    - Test validation completes within specified timeout
+    - Test timeout error handling
+
+- [ ] 4. Implement configuration manager integration
+  - [ ] 4.1 Add validation to initialize function
+    - Update `initializeWallet` to call validation service
+    - Validate new address before storing configuration
+    - Return error if validation fails
+    - Store validated address on success
+    - _Requirements: 1.1, 1.2, 1.3_
+
+  - [ ] 4.2 Add validation to update function
+    - Update `updateWallet` to call validation service
+    - Validate new address before updating configuration
+    - Return error and preserve existing config on failure
+    - Update address on validation success
+    - _Requirements: 2.1, 2.2, 2.3_
+
+  - [ ] 4.3 Add validation status field to config
+    - Add `validationStatus` field to wallet configuration
+    - Add `lastValidatedAt` timestamp field
+    - Add `lastError` field for error details
+    - Update configuration storage schema
+    - _Requirements: 1, 2, 6_
+
+  - [ ]\* 4.4 Write unit tests for configuration manager
+    - Test successful initialization with valid address
+    - Test rejection of invalid address during initialization
+    - Test successful update with valid address
+    - Test rejection of invalid address during update
+    - Test config preservation on failure
+    - _Requirements: 1, 2, 6.3_
+
+- [ ] 5. Implement escrow operation integration
+  - [ ] 5.1 Add validation check to escrow processing
+    - Update payment service to check wallet validity
+    - Verify platform wallet is configured before commission transfer
+    - Add validation status check to escrow transaction processing
+    - _Requirements: 7.1_
+
+  - [ ] 5.2 Add warning logging for invalid config
+    - Implement warning log when wallet is invalid
+    - Log warning before attempting commission transfer
+    - Continue escrow processing despite invalid wallet
+    - _Requirements: 7.2_
+
+  - [ ] 5.3 Implement commission transfer with validation
+    - Update commission calculation logic
+    - Transfer commission to validated platform wallet address
+    - Handle transfer failures gracefully
+    - _Requirements: 7.3_
+
+  - [ ]\* 5.4 Write integration tests for escrow integration
+    - Test escrow processing with valid wallet
+    - Test escrow processing with invalid wallet (warning logged)
+    - Test commission transfer to validated wallet
+    - _Requirements: 7.1, 7.2, 7.3_
+
+- [ ] 6. Implement logging and error handling
+  - [ ] 6.1 Implement validation logging
+    - Create `ValidationLogEntry` storage
+    - Log all validation attempts with timestamp
+    - Include wallet address, result, errors, duration
+    - Support audit trail queries
+    - _Requirements: 6.2_
+
+  - [ ] 6.2 Implement error handling
+    - Create `ValidationErrorCode` enum
+    - Implement descriptive error messages
+    - Handle format validation errors
+    - Handle ping failures with specific codes
+    - Handle account not found errors
+    - Handle contract rejection errors
+    - Handle timeout errors
+    - Handle network errors
+    - _Requirements: 6.1, 8.3_
+
+  - [ ] 6.3 Implement error response format
+    - Create standardized error response structure
+    - Include error code, message, details, timestamp
+    - Support error aggregation for multiple failures
+    - _Requirements: 6.1_
+
+- [ ] 7. Implement configuration storage
+  - [ ] 7.1 Create platform wallet configuration storage
+    - Implement `PlatformWalletConfig` storage
+    - Add `createdAt` and `updatedAt` timestamps
+    - Implement persistent storage mechanism
+    - Support configuration retrieval
+    - _Requirements: 1.3, 2.3_
+
+  - [ ] 7.2 Implement configuration versioning
+    - Add version field to configuration
+    - Support configuration migration
+    - Track configuration changes over time
+    - _Requirements: 1, 2_
+
+- [ ] 8. Integration and wiring
+  - [ ] 8.1 Wire validation service to configuration manager
+    - Inject validation service into configuration manager
+    - Connect validation calls in initialize and update
+    - Handle validation results appropriately
+    - _Requirements: 1, 2, 3, 4, 5, 6, 7, 8_
+
+  - [ ] 8.2 Wire configuration manager to escrow operations
+    - Inject configuration manager into payment service
+    - Connect wallet validity checks in escrow processing
+    - Connect commission transfer logic
+    - _Requirements: 7.1, 7.2, 7.3_
+
+  - [ ]\* 8.3 Write integration tests for full validation flow
+    - Test complete validation sequence end-to-end
+    - Test initialization with validation
+    - Test update with validation
+    - Test escrow processing with validation
+    - _Requirements: 1, 2, 3, 4, 5, 6, 7, 8_
+
+  - [ ]\* 8.4 Write property test for configuration preservation
+    - **Property 2: Validation preserves existing configuration on failure**
+    - **Validates: Requirements 1.3, 2.2, 6.3**
+    - Test that existing config is preserved on validation failure
+    - Test that new config is stored on validation success
+
+  - [ ]\* 8.5 Write property test for audit logging
+    - **Property 3: Validation logs all attempts for audit trail**
+    - **Validates: Requirement 6.2**
+    - Test that all validation attempts are logged
+    - Test log entry contains required fields
+
+- [ ] 9. Checkpoint - Ensure all tests pass
+  - Run all unit tests and fix any failures
+  - Run all integration tests and fix any failures
+  - Ensure property-based tests pass
+  - Ensure all acceptance criteria are covered
+  - Ask the user if questions arise.
+
+- [ ] 10. Documentation
+  - [ ] 10.1 Add API documentation for validation service
+    - Document `validateWallet` function
+    - Document `zeroAmountPing` function
+    - Document `checkAccountExists` function
+    - Document `checkContractTransfers` function
+    - Include usage examples
+    - _Requirements: 1, 2, 3, 4, 5, 6, 7, 8_
+
+  - [ ] 10.2 Add configuration guide for platform wallet setup
+    - Document initialization process
+    - Document update process
+    - Document validation requirements
+    - Document error handling
+    - Include troubleshooting guide
+    - _Requirements: 1, 2, 6_
+
+- [ ] 11. Final checkpoint - Ensure all tests pass
+  - Run full test suite
+  - Verify all 24 acceptance criteria are covered
+  - Verify all correctness properties are tested
+  - Ensure no regressions in existing functionality
+  - Ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties
+- Unit tests validate specific examples and edge cases
+- All implementation will use TypeScript based on the design document
+- The validation service will integrate with Stellar Horizon API and Soroban RPC API
+- Default timeout for validation is 5 seconds as specified in requirements

--- a/.kiro/specs/volume-metrics-refund-bugfix/bugfix.md
+++ b/.kiro/specs/volume-metrics-refund-bugfix/bugfix.md
@@ -1,0 +1,35 @@
+# Bugfix Requirements Document
+
+## Introduction
+
+This bugfix addresses an issue where user trade volume metrics are artificially inflated when escrow refunds occur. The `update_user_metrics` function is called with `volume_delta` during refund operations, which incorrectly counts refunded amounts as part of a user's trade volume. This metric is used for auto-verification thresholds and reputation calculations, so inaccurate volume tracking can lead to incorrect user verification status.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+1.1 WHEN an escrow is refunded via the `refund` function THEN the system updates volume metrics for the seller with the full escrow amount
+
+1.2 WHEN a dispute is resolved with `RefundToBuyer` resolution THEN the system updates volume metrics for the seller with the full escrow amount
+
+1.3 WHEN volume metrics are updated on refund paths THEN the user's trade volume is artificially inflated, potentially triggering false auto-verification
+
+### Expected Behavior (Correct)
+
+2.1 WHEN an escrow is refunded via the `refund` function THEN the system SHALL NOT update volume metrics for any party
+
+2.2 WHEN a dispute is resolved with `RefundToBuyer` resolution THEN the system SHALL NOT update volume metrics for any party
+
+2.3 WHEN volume metrics are updated on refund paths THEN the system SHALL CONTINUE TO skip the metrics update entirely
+
+### Unchanged Behavior (Regression Prevention)
+
+3.1 WHEN an escrow is released via `release_funds` THEN the system SHALL CONTINUE TO update volume metrics for the seller
+
+3.2 WHEN an escrow is auto-released via `auto_release` THEN the system SHALL CONTINUE TO update volume metrics for the seller
+
+3.3 WHEN a dispute is resolved with `ReleaseToSeller` resolution THEN the system SHALL CONTINUE TO update volume metrics for the seller
+
+3.4 WHEN a recurring escrow cycle completes successfully THEN the system SHALL CONTINUE TO update volume metrics for the artisan
+
+3.5 WHEN volume metrics are updated for successful transactions THEN the system SHALL CONTINUE TO normalize the volume amount based on token decimals before adding to total_volume


### PR DESCRIPTION
### Lacking Support for NFT or Semi-Fungible Collateral

**Issue:** The contract only natively supports standard Soroban fungible tokens for stakes. Artisans might want to stake NFTs, specialized receipt tokens, or wrapped assets as collateral.

**Solution:** Added comprehensive support for multiple token standards:
- Token standard detection (fungible, NFT, semi-fungible) with priority-based selection
- NFT ownership validation with token ID verification
- Semi-fungible balance tracking and quantity validation
- NFT metadata handling
- Backward compatibility with existing fungible tokens
- Unified collateral interface for all token types

**Files:** `.kiro/specs/nft-collateral-support/`

this pr Closes #202 
