### PR TITLE
Fix escrow minimum dust handling, admin transfer cancel, refund fee-safe validation, and max release-window ceiling

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -147,6 +147,8 @@ const DEFAULT_STAKE_COOLDOWN: u32 = 7 * 24 * 60 * 60;
 
 /// Default minimum release window to prevent "flash" auto-releases (1 day in seconds)
 const DEFAULT_MIN_RELEASE_WINDOW: u32 = 24 * 60 * 60;
+/// Absolute safety ceiling for admin-configurable max release window (365 days).
+const ABSOLUTE_MAX_RELEASE_WINDOW: u32 = 365 * 24 * 60 * 60;
 
 /// Maximum platform fee in basis points (10000 = 100%)
 const MAX_PLATFORM_FEE_BPS: u32 = 1000; // 10% max
@@ -792,7 +794,10 @@ impl EscrowContract {
         env.storage().temporary().remove(&DataKey::ReentryGuard);
     }
 
-    pub fn check_min_amount(env: &Env, token: Address, amount: i128) -> Result<(), Error> {
+    // IMPORTANT: this validation is intentionally scoped to escrow creation-time
+    // flows only. Do not call from payout/distribution paths, or dynamic minimum
+    // changes could trap dust balances in existing escrows.
+    fn check_min_amount(env: &Env, token: Address, amount: i128) -> Result<(), Error> {
         if amount <= 0 {
             return Err(Error::AmountBelowMinimum);
         }
@@ -866,12 +871,16 @@ impl EscrowContract {
     /// Set the configurable maximum release window (admin only).
     ///
     /// # Arguments
-    /// * `max_window` - Maximum allowed release window in seconds (must be > 0)
+    /// * `max_window` - Maximum allowed release window in seconds.
+    ///   Must be > 0 and <= ABSOLUTE_MAX_RELEASE_WINDOW.
     pub fn set_max_release_window(env: Env, max_window: u32) {
         let config = Self::get_platform_config_internal(&env);
         config.admin.require_auth();
         if max_window == 0 {
             env.panic_with_error(crate::Error::ReleaseWindowTooShort);
+        }
+        if max_window > ABSOLUTE_MAX_RELEASE_WINDOW {
+            env.panic_with_error(crate::Error::ReleaseWindowTooLong);
         }
         env.storage()
             .persistent()
@@ -1115,6 +1124,21 @@ impl EscrowContract {
 
         env.storage().persistent().set(&DataKey::PlatformConfig, &config);
         Self::extend_persistent(&env, &DataKey::PlatformConfig);
+    }
+
+    /// Cancel an in-progress two-step admin transfer (current admin only).
+    pub fn cancel_admin_transfer(env: Env) -> Result<(), Error> {
+        let mut config = Self::get_platform_config_internal(&env);
+        config.admin.require_auth();
+
+        if config.pending_admin.is_none() {
+            return Err(Error::NoPendingAdmin);
+        }
+
+        config.pending_admin = None;
+        env.storage().persistent().set(&DataKey::PlatformConfig, &config);
+        Self::extend_persistent(&env, &DataKey::PlatformConfig);
+        Ok(())
     }
 
     /// Migrate a user's escrow list from legacy vector storage to indexed storage.
@@ -3629,7 +3653,8 @@ impl EscrowContract {
     ///
     /// # Arguments
     /// * `order_id` - Order identifier
-    /// * `refund_amount` - Amount to refund to the buyer
+    /// * `refund_amount` - Gross amount to refund to the buyer before any
+    ///   potential refund-side platform fee is deducted.
     /// * `proposed_by` - Address of the party proposing the refund (must be buyer or seller)
     pub fn propose_partial_refund(
         env: Env,
@@ -3655,7 +3680,9 @@ impl EscrowContract {
         // Require auth from the proposing party
         caller.require_auth();
 
-        if refund_amount <= 0 || refund_amount > escrow.amount {
+        // `refund_amount` is interpreted as gross; validation includes any
+        // configured refund-side fee to ensure transfers remain solvent.
+        if !Self::is_valid_partial_refund_gross_amount(&env, &escrow, refund_amount) {
             return Err(Error::InvalidRefundAmount);
         }
 
@@ -3756,8 +3783,9 @@ impl EscrowContract {
     /// Accept the outstanding partial refund proposal for a disputed escrow.
     ///
     /// The counterparty (the party that did NOT submit the proposal) calls this function.
-    /// Funds are distributed: buyer receives `refund_amount`, seller receives the remainder
-    /// minus the platform fee. The escrow status is set to Resolved.
+    /// Funds are distributed from a gross refund model: buyer receives
+    /// `refund_amount - refund_fee`, seller receives the remainder minus seller-side
+    /// platform fee. The escrow status is set to Resolved.
     pub fn accept_partial_refund(env: Env, order_id: u32) -> Result<(), Error> {
         let escrow_opt: Option<Escrow> = env.storage().persistent().get(&(ESCROW, order_id));
         if escrow_opt.is_none() {
@@ -3784,14 +3812,17 @@ impl EscrowContract {
             escrow.buyer.require_auth();
         }
 
-        let refund_amount = proposal.refund_amount;
-        let seller_gross = escrow.amount - refund_amount;
+        let refund_amount_gross = proposal.refund_amount;
+        let refund_fee = Self::calculate_partial_refund_fee(&env, refund_amount_gross);
+        let refund_amount_net = refund_amount_gross - refund_fee;
+        let seller_gross = escrow.amount - refund_amount_gross;
 
         // Deduct platform fee from seller's portion using effective fee bps
         let config = Self::get_platform_config_internal(&env);
         let fee_bps = Self::get_effective_fee_bps(env.clone(), escrow.seller.clone());
-        let fee_amount = Self::calculate_fee(seller_gross, fee_bps);
-        let seller_net = seller_gross - fee_amount;
+        let seller_fee = Self::calculate_fee(seller_gross, fee_bps);
+        let seller_net = seller_gross - seller_fee;
+        let total_platform_fee = refund_fee.saturating_add(seller_fee);
 
         // CEI Pattern: EFFECTS - Update state BEFORE external calls
         escrow.status = EscrowStatus::Resolved;
@@ -3808,17 +3839,22 @@ impl EscrowContract {
         let token_client = token::Client::new(&env, &escrow.token);
 
         // Refund buyer
-        if refund_amount > 0 {
+        if refund_amount_net > 0 {
             token_client.transfer(
                 &env.current_contract_address(),
                 &escrow.buyer,
-                &refund_amount,
+                &refund_amount_net,
             );
         }
 
         // Pay platform fee
-        if fee_amount > 0 {
-            Self::transfer_platform_fee(&env, &escrow.token, &config.platform_wallet, fee_amount);
+        if total_platform_fee > 0 {
+            Self::transfer_platform_fee(
+                &env,
+                &escrow.token,
+                &config.platform_wallet,
+                total_platform_fee,
+            );
         }
 
         // Pay seller
@@ -3843,6 +3879,31 @@ impl EscrowContract {
         );
 
         Ok(())
+    }
+
+    /// Returns the currently configured refund-side fee basis points.
+    ///
+    /// Today this is intentionally fixed at 0 bps. A future governance feature
+    /// can replace this implementation with configurable storage without changing
+    /// partial-refund validation semantics.
+    fn get_refund_fee_bps(_env: &Env) -> u32 {
+        0
+    }
+
+    /// Calculate refund-side fee charged against a proposed gross partial refund.
+    fn calculate_partial_refund_fee(env: &Env, gross_refund_amount: i128) -> i128 {
+        let refund_fee_bps = Self::get_refund_fee_bps(env);
+        Self::calculate_fee(gross_refund_amount, refund_fee_bps)
+    }
+
+    /// Validate gross partial refund amount against escrow solvency including any
+    /// potential refund-side fee that may apply.
+    fn is_valid_partial_refund_gross_amount(env: &Env, escrow: &Escrow, gross_refund: i128) -> bool {
+        if gross_refund <= 0 || gross_refund > escrow.amount {
+            return false;
+        }
+        let potential_refund_fee = Self::calculate_partial_refund_fee(env, gross_refund);
+        gross_refund.saturating_add(potential_refund_fee) <= escrow.amount
     }
 
     /// Check if a user has any active traditional or recurring escrows.

--- a/craft-nexus-contract/src/test.rs
+++ b/craft-nexus-contract/src/test.rs
@@ -946,6 +946,32 @@ fn test_admin_transfer_flow() {
 }
 
 #[test]
+fn test_admin_transfer_can_be_cancelled() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _, _, admin) = setup_test(&env, true);
+
+    let new_admin = Address::generate(&env);
+    client.update_admin(&new_admin);
+
+    client.cancel_admin_transfer().unwrap();
+
+    let config = client.get_platform_config();
+    assert_eq!(config.admin, admin);
+    assert_eq!(config.pending_admin, None);
+}
+
+#[test]
+fn test_cancel_admin_transfer_without_pending_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _, _, _) = setup_test(&env, true);
+
+    let result = client.try_cancel_admin_transfer();
+    assert!(result.is_err());
+}
+
+#[test]
 #[should_panic]
 fn test_claim_admin_no_pending_fails() {
     let env = Env::default();
@@ -1410,6 +1436,34 @@ fn test_create_escrow_below_custom_minimum() {
 
     token_admin.mint(&buyer, &100_000_000);
     client.create_escrow(&buyer, &seller, &token_id, &40_000_000, &1, &None); // Should panic
+}
+
+#[test]
+fn test_partial_refund_allows_dust_after_minimum_increase() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, token_admin, _, _) = setup_test(&env, true);
+
+    token_admin.mint(&buyer, &100_000_000);
+
+    // Creation-time minimum check: escrow is valid at creation.
+    client.set_min_escrow_amount(&token_id, &10_000);
+    client.create_escrow(&buyer, &seller, &token_id, &50_000, &1, &None);
+
+    // Admin raises minimum above any potential remainder after split.
+    client.set_min_escrow_amount(&token_id, &100_000);
+
+    // Dispute + partial refund leaves only a dust remainder for seller.
+    client.dispute_escrow(&1, &String::from_str(&env, "Dust split"), &buyer);
+    client.propose_partial_refund(&1, &49_990, &buyer);
+    client.accept_partial_refund(&1);
+
+    let escrow = client.get_escrow(&1);
+    assert_eq!(escrow.status, EscrowStatus::Resolved);
+
+    let token_client = token::Client::new(&env, &token_id);
+    assert_eq!(token_client.balance(&buyer), 99_999_990);
+    assert_eq!(token_client.balance(&seller), 10);
 }
 
 #[test]
@@ -2004,6 +2058,33 @@ fn test_set_max_release_window_zero_panics() {
     let (client, _, _, _, _, _, _) = setup_test(&env, true);
 
     client.set_max_release_window(&0u32);
+}
+
+/// set_max_release_window above the hard safety ceiling must be rejected.
+#[test]
+#[should_panic]
+fn test_set_max_release_window_above_absolute_ceiling_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, _, _, _, _, _, _) = setup_test(&env, true);
+
+    // 366 days > hardcoded 365-day ceiling.
+    client.set_max_release_window(&(366u32 * 24 * 60 * 60));
+}
+
+#[test]
+fn test_set_max_release_window_at_absolute_ceiling_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, token_admin, _, _) = setup_test(&env, true);
+    token_admin.mint(&buyer, &100_000_000);
+
+    let ceiling = 365u32 * 24 * 60 * 60;
+    client.set_max_release_window(&ceiling);
+    client.create_escrow(&buyer, &seller, &token_id, &1000, &1, &Some(ceiling));
+
+    let escrow = client.get_escrow(&1);
+    assert_eq!(escrow.release_window, ceiling);
 }
 
 // ============================================================
@@ -3045,4 +3126,23 @@ fn test_accept_partial_refund_with_custom_fee_tier() {
 
     let token_client = token::Client::new(&env, &token_id);
     assert_eq!(token_client.balance(&seller), 490);
+}
+
+#[test]
+fn test_partial_refund_full_gross_amount_is_valid() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, buyer, seller, token_id, token_admin, _, _) = setup_test(&env, true);
+
+    token_admin.mint(&buyer, &1000);
+    client.create_escrow(&buyer, &seller, &token_id, &1000, &1, &None);
+    client.dispute_escrow(&1, &String::from_str(&env, "Full gross refund"), &buyer);
+
+    // refund_amount is interpreted as gross and is valid when it equals escrow.amount.
+    client.propose_partial_refund(&1, &1000, &buyer);
+    client.accept_partial_refund(&1);
+
+    let token_client = token::Client::new(&env, &token_id);
+    assert_eq!(token_client.balance(&buyer), 1000);
+    assert_eq!(token_client.balance(&seller), 0);
 }


### PR DESCRIPTION
## Summary
This PR resolves four contract logic/security issues across admin governance, escrow minimum enforcement, refund validation, and release-window safety bounds.

## Issues Resolved
Closes #204
Closes #199
Closes #209
Closes #203

## What Changed
1. #204 Minimum escrow check scoped to creation only
- Kept minimum-amount enforcement exclusively on escrow creation-time validation paths.
- Tightened helper visibility and documented intent to prevent accidental use in payout/distribution paths.
- Added regression coverage proving partial-refund settlement can still complete after admin raises minimums, even when the remainder is dust.

2. #199 Added cancellable two-step admin transfer
- Added new function: cancel_admin_transfer(env: Env) -> Result<(), Error>.
- Authorization: current admin only.
- Behavior: clears pending_admin before claim and returns NoPendingAdmin if nothing is pending.
- Added tests for both success and no-pending failure paths.

3. #209 Clarified refund semantics and made validation fee-aware
- Clarified partial-refund proposal semantics: refund_amount is treated as gross buyer refund.
- Added fee-aware solvency validation before accepting refund proposals:
  - validates gross_refund > 0 and gross_refund <= escrow.amount
  - validates gross_refund + potential_refund_fee <= escrow.amount
- Added internal helpers to compute potential refund-side fee (currently fixed to 0 bps, future-ready).
- Updated payout path to compute buyer net refund and aggregate platform fee components deterministically.
- Added regression test confirming full gross refund amount remains valid under current 0-bps refund fee configuration.

4. #203 Hard ceiling on max release window
- Introduced ABSOLUTE_MAX_RELEASE_WINDOW = 365 days as a hard safety bound.
- Enforced in set_max_release_window:
  - rejects 0 (existing behavior)
  - rejects any value above the 365-day absolute ceiling
- Added tests for rejection above the ceiling and acceptance exactly at the ceiling.

## Why This Is Safe
- No payout paths now apply token minimum checks, preventing dust-lock regressions from admin minimum changes.
- Admin transfer remains two-step but now recoverable until claim is executed.
- Refund proposal validation is explicit about gross-vs-net semantics and forward-compatible with non-zero refund fees.
- Release-window governance power is mathematically bounded to prevent intentional long-lock DoS.

## Testing
- Added/updated targeted unit tests in craft-nexus-contract/src/test.rs for all new behavior.
- Note: full cargo test currently encounters pre-existing compile errors in unrelated legacy test modules (e.g., reentrancy_test.rs) that are outside this PR scope.
- Verified modified files are free of diagnostics.