### PR TITLE
fix(escrow): tighten legacy storage hygiene and bound recurring escrow IDs

### DIFF
--- a/craft-nexus-contract/docs/deprecated-storage.md
+++ b/craft-nexus-contract/docs/deprecated-storage.md
@@ -1,0 +1,119 @@
+# Deprecated storage and bounded growth
+
+This note covers four storage-hygiene tracks landed together. Each refers
+back to a specific issue and the exact `DataKey` it touches, so a future
+maintainer can decide whether the legacy compatibility shim is still
+worth carrying.
+
+## `DataKey::ReferralRewardBps` — Issue #234
+
+* Status: **deprecated, retained for ABI compatibility only**.
+* What it stored: a `u32` basis-points figure that an admin could set via
+  `set_referral_reward_bps`.
+* Why it was kept: referral payout logic was scoped but never shipped.
+  The slot was preserved in case clients had already serialized the call.
+
+### Active behaviour
+
+* `set_referral_reward_bps` now panics with
+  `Error::DeprecatedFunction` after admin auth. No new value can be
+  written to the slot; existing entries from older deployments are
+  inert.
+* `get_referral_reward_bps` always returns `0`. It does not read the
+  legacy slot, so callers cannot accidentally rely on stale state.
+* No payout, fee, or reward path in the contract reads
+  `DataKey::ReferralRewardBps`. Grep is the source of truth — if a new
+  PR adds a read, it must clear the deprecation in this doc first.
+
+### Migration path
+
+If a future feature wants to revive referrals it must introduce a fresh
+`DataKey` variant. Re-using `ReferralRewardBps` is forbidden because we
+cannot distinguish "value left over from a 2024 deployment" from
+"intentional new value".
+
+## `DataKey::StakeCooldownEnd(Address)` — Issue #235
+
+* Status: **deprecated, written for legacy clients but never read by
+  active logic**.
+* What it stored: a single `u64` cooldown timestamp per artisan.
+* Why it was kept: older off-chain readers polled this key directly to
+  show "stake unlocks at …" without understanding the queue layout.
+
+### Active behaviour
+
+* Active staking uses [`DataKey::ArtisanStakeQueue`]. `unstake_tokens`
+  never reads the single timestamp; matured deposits are decided per
+  queue entry.
+* `stake_tokens` and `unstake_tokens` continue to mirror the maximum
+  `cooldown_end` from the queue into this key so legacy readers still
+  see a conservative value. Both call sites are now annotated with
+  "DEPRECATED storage write" comments referencing this issue.
+* When a queue empties, `unstake_tokens` removes the deprecated key
+  alongside the queue and the stake record.
+* Operators can call `purge_stake_cooldown_end(artisan)` (admin-only)
+  to clear a stale entry without disturbing the queue. The function
+  returns `true` when an entry was removed and `false` otherwise.
+
+### Migration path
+
+When the off-chain readers that depend on this single timestamp are
+retired, drop both the mirror writes in `stake_tokens`/`unstake_tokens`
+and the `DataKey::StakeCooldownEnd` variant in the same release. Until
+then, the key must remain a *write-only* mirror.
+
+## `DataKey::NextRecurringEscrowId` — Issue #233
+
+* Status: **active, but bounded**.
+* What it stores: the next `u64` ID for a recurring escrow.
+
+### Active behaviour
+
+* `MAX_RECURRING_ESCROW_ID = u64::MAX - 1` (defined in `lib.rs`) is the
+  hard ceiling. `u64::MAX` is reserved as a sentinel.
+* `create_recurring_escrow` rejects allocation past the cap with
+  `Error::RecurringEscrowIdExhausted`. The increment uses
+  `checked_add`, so the contract panics loudly rather than wrapping
+  into an existing ID.
+* The cap is far above any realistic deployment lifetime (one new
+  recurring escrow per ledger for ~3 trillion years), so the bound is
+  defensive — not a near-term operational concern. Its purpose is to
+  remove the silent-collision failure mode entirely.
+
+### Migration path
+
+If recurring escrow churn ever needs ID recycling (e.g. a contract
+fork that prunes long-cancelled escrows), introduce a separate
+allocator with explicit free-list semantics; do not lower the cap on
+this counter without a coordinated migration.
+
+## `DataKey::BuyerEscrowCount` / `DataKey::SellerEscrowCount` — Issue #244
+
+* Status: **active, indexed pattern documented**.
+* What they store: a single `u32` per buyer/seller giving the total
+  number of escrows that party has been involved in.
+
+### Scaling characteristics
+
+* Per-account: **O(1) storage**, **O(1) updates**. One ledger entry
+  per buyer/seller, irrespective of how many escrows they have.
+* Per-platform: footprint scales with the number of distinct
+  participants, not with the number of escrows. There is no 64KB
+  per-key limit to worry about because every escrow ID lives in its
+  own `BuyerEscrowIndexed`/`SellerEscrowIndexed` entry.
+* Pagination: `get_escrows_by_buyer` / `get_escrows_by_seller` read
+  one indexed entry per item per page; cost is bounded by the page
+  size, not the total count.
+* TTL: like every other persistent entry, counts obey the standard
+  TTL extension (`TTL_EXTENSION`). Inactive accounts archive
+  naturally.
+
+### Why not a sparser alternative?
+
+A bitmap or sharded counter would compress storage if the platform had
+millions of accounts that each held only a handful of escrows, but it
+would penalise the common case (frequent reads/writes by active
+buyers/sellers) with extra masking and indirection. The current
+single-entry `u32` is the cheapest design that still preserves O(1)
+updates and supports the indexed pagination pattern. We will revisit
+if telemetry shows unique-account growth dominating storage cost.

--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -117,6 +117,10 @@ pub enum Error {
     UpgradeProposalExists = 44,
     /// Onboarding contract address is not configured
     OnboardingContractNotSet = 45,
+    /// Recurring escrow ID space exhausted; no further IDs can be allocated
+    RecurringEscrowIdExhausted = 46,
+    /// Function is deprecated and no longer accepts writes
+    DeprecatedFunction = 47,
 }
 
 #[cfg(not(target_family = "wasm"))]
@@ -166,6 +170,15 @@ const CURRENT_ESCROW_VERSION: u32 = 3;
 const MAX_BATCH_SIZE: u32 = 20;
 /// Timeout for unfunded escrows before they can be cancelled (24 hours) (#213)
 const UNFUNDED_CANCEL_TIMEOUT: u64 = 24 * 60 * 60;
+/// Hard ceiling for `NextRecurringEscrowId` (Issue #233).
+///
+/// `u64::MAX` is reserved as a sentinel so the allocator can detect an
+/// exhausted ID space without wrapping. At the realistic peak rate of
+/// one new recurring escrow per ledger this cap is far beyond any
+/// practical deployment lifetime, but the explicit bound lets us fail
+/// fast with `Error::RecurringEscrowIdExhausted` instead of silently
+/// colliding with an existing entry.
+const MAX_RECURRING_ESCROW_ID: u64 = u64::MAX - 1;
 /// Maximum number of upgrade records retained in `UpgradeHistory`. Older
 /// records are dropped FIFO once the cap is reached. Sized so a contract
 /// upgraded twice a year for ~16 years still has full visibility.
@@ -196,13 +209,32 @@ pub enum DataKey {
     PlatformConfig,
     /// Custom fee tier for an artisan (basis points)
     ArtisanFeeTier(Address),
-    /// Deprecated referral reward percentage in basis points.
-    /// Retained only for storage compatibility; referral payout logic is not implemented.
+    /// DEPRECATED legacy referral reward percentage in basis points.
+    ///
+    /// Referral payout logic was never shipped, so this value does **not**
+    /// influence any fee, payout, or reward path in the active contract. It
+    /// is retained only as a read-only historical key so a future migration
+    /// can inspect what older deployments stored.
+    ///
+    /// New code MUST NOT read or write this key. The only public accessors
+    /// (`set_referral_reward_bps` / `get_referral_reward_bps`) are kept for
+    /// ABI compatibility and are documented as legacy. See
+    /// `docs/deprecated-storage.md`.
     ReferralRewardBps,
     /// Staked token amount and asset for an artisan
     ArtisanStake(Address),
-    /// Timestamp when the stake cooldown ends for an artisan (DEPRECATED)
-    /// Backwards-compatible single timestamp kept for older clients.
+    /// DEPRECATED single-cooldown timestamp for an artisan.
+    ///
+    /// Active stake/unstake logic uses [`DataKey::ArtisanStakeQueue`]; this
+    /// key is **never read** by any code path in the live contract and
+    /// cannot influence cooldown decisions. It is updated alongside the
+    /// queue (set to the latest `cooldown_end`) purely so older read-only
+    /// clients still see a meaningful value. Once a queue is fully
+    /// drained the key is removed in `unstake_tokens`.
+    ///
+    /// Admins may also call `purge_stake_cooldown_end` to remove a stale
+    /// entry without touching the queue. See Issue #235 and
+    /// `docs/deprecated-storage.md`.
     StakeCooldownEnd(Address),
     /// Per-deposit stake queue for an artisan. Each entry represents an
     /// individual deposit and its cooldown end timestamp. This allows
@@ -229,7 +261,13 @@ pub enum DataKey {
     EscrowCount,
     /// Key for a recurring escrow by its ID
     RecurringEscrow(u64),
-    /// ID counter for recurring escrows
+    /// Monotonically incrementing counter for recurring escrow IDs.
+    ///
+    /// IDs allocate from `1..=MAX_RECURRING_ESCROW_ID` (see the constant
+    /// of the same name). Allocation past the cap is rejected with
+    /// `Error::RecurringEscrowIdExhausted` rather than wrapping, so
+    /// recurring escrow creation fails loudly instead of silently
+    /// colliding with an existing entry. See Issue #233.
     NextRecurringEscrowId,
     /// Count of currently active (non-released, non-refunded) escrows or recurring escrows for a user address.
     /// Used as a barrier for profile deactivation.
@@ -237,12 +275,25 @@ pub enum DataKey {
     /// Indexed storage for buyer escrows: (Address, Index) -> EscrowId
     /// Supports unlimited history without 64KB vector limit
     BuyerEscrowIndexed(Address, u32),
-    /// Total count of escrows for a buyer
+    /// Per-buyer escrow count (u32). Scaling notes (Issue #244):
+    ///
+    /// * Storage cost is **O(1) per buyer**: a single `u32` value plus the
+    ///   key envelope. Total footprint scales with the number of distinct
+    ///   buyers, not with the number of escrows.
+    /// * Reads/writes touch a single ledger entry, so per-account count
+    ///   updates remain constant-time even at very high user growth.
+    /// * Inactive buyers' counts behave like any other persistent entry —
+    ///   they obey the standard TTL extension (`TTL_EXTENSION`) and can
+    ///   archive naturally if a buyer becomes dormant.
+    /// * Pagination over a buyer's escrows uses `BuyerEscrowIndexed`
+    ///   (sparse, one entry per escrow), not a single `Vec`, so the 64KB
+    ///   per-key limit never bottlenecks heavy users.
     BuyerEscrowCount(Address),
     /// Indexed storage for seller escrows: (Address, Index) -> EscrowId
     /// Supports unlimited history without 64KB vector limit
     SellerEscrowIndexed(Address, u32),
-    /// Total count of escrows for a seller
+    /// Per-seller escrow count (u32). Same scaling characteristics as
+    /// `BuyerEscrowCount` — see that variant for full notes (Issue #244).
     SellerEscrowCount(Address),
     /// Total amount of funds locked in active escrows or recurring escrows for a token address.
     /// Used for sweeping unallocated funds (#212).
@@ -1731,6 +1782,7 @@ impl EscrowContract {
         let escrow = Escrow {
             version: CURRENT_ESCROW_VERSION,
             id: order_id as u64,
+            batch_id: None,
             buyer: buyer.clone(),
             seller: seller.clone(),
             token: token.clone(),
@@ -2118,6 +2170,7 @@ impl EscrowContract {
             metadata_hash: escrow.metadata_hash,
             dispute_reason: escrow.dispute_reason,
             dispute_initiated_at: escrow.dispute_initiated_at,
+            funded: true,
         }
     }
 
@@ -3948,34 +4001,53 @@ impl EscrowContract {
         }
     }
 
-    // ── Referral Rewards (#105) ─────────────────────────────────────
+    // ── Referral Rewards (#105, DEPRECATED — see Issue #234) ────────
 
-    /// Admin sets the referral reward percentage (basis points of the platform fee).
-    pub fn set_referral_reward_bps(env: Env, bps: u32) {
+    /// DEPRECATED. Setting a referral reward has no effect on payouts.
+    ///
+    /// Referral logic was never implemented; this entry point is kept only
+    /// to preserve the published ABI. Calling it now panics with
+    /// `Error::DeprecatedFunction` so no new state is written to the
+    /// legacy `DataKey::ReferralRewardBps` slot. See
+    /// `docs/deprecated-storage.md` for the migration policy.
+    pub fn set_referral_reward_bps(env: Env, _bps: u32) {
         let admin = Self::get_admin(&env)
             .unwrap_or_else(|_| env.panic_with_error(crate::Error::Unauthorized));
         admin.require_auth();
-        if bps > 5000 {
-            env.panic_with_error(crate::Error::InvalidFee);
-        }
-        env.storage()
-            .persistent()
-            .set(&DataKey::ReferralRewardBps, &bps);
-        Self::extend_persistent(&env, &DataKey::ReferralRewardBps);
+        env.panic_with_error(crate::Error::DeprecatedFunction);
     }
 
-    /// Get the referral reward basis points.
-    pub fn get_referral_reward_bps(env: Env) -> u32 {
-        let key = DataKey::ReferralRewardBps;
-        let bps = env
-            .storage()
-            .persistent()
-            .get::<DataKey, u32>(&key)
-            .unwrap_or(0);
+    /// DEPRECATED. Always returns `0`.
+    ///
+    /// Older deployments may still have a value at
+    /// `DataKey::ReferralRewardBps`, but the figure is unused by every
+    /// payout path in this contract. Returning a constant `0` removes any
+    /// ambiguity for clients that still call this and prevents accidental
+    /// reliance on stale data. See `docs/deprecated-storage.md`.
+    pub fn get_referral_reward_bps(_env: Env) -> u32 {
+        0
+    }
+
+    /// Admin-only cleanup for the deprecated `StakeCooldownEnd` slot.
+    ///
+    /// Removes a stale single-timestamp cooldown entry for `artisan`
+    /// without touching `ArtisanStakeQueue`. Active staking logic relies
+    /// solely on the queue, so this is purely a storage hygiene tool for
+    /// operators who want to clear unused legacy keys. Returns `true` if
+    /// an entry was removed, `false` if there was nothing to clean up.
+    /// See Issue #235.
+    pub fn purge_stake_cooldown_end(env: Env, artisan: Address) -> bool {
+        let admin = Self::get_admin(&env)
+            .unwrap_or_else(|_| env.panic_with_error(crate::Error::Unauthorized));
+        admin.require_auth();
+
+        let key = DataKey::StakeCooldownEnd(artisan);
         if env.storage().persistent().has(&key) {
-            Self::extend_persistent(&env, &key);
+            env.storage().persistent().remove(&key);
+            true
+        } else {
+            false
         }
-        bps
     }
 
     // ── Dispute Resolution Deadline (#93) ───────────────────────────
@@ -4147,10 +4219,11 @@ impl EscrowContract {
         env.storage().persistent().set(&queue_key, &queue);
         Self::extend_persistent(&env, &queue_key);
 
-        // Maintain deprecated single timestamp for backwards compatibility: set to
-        // the maximum cooldown_end across deposits (i.e., time when all current
-        // deposits will be matured). This ensures older clients still see a
-        // conservative cooldown value.
+        // DEPRECATED storage write — see Issue #235 and the docs on
+        // `DataKey::StakeCooldownEnd`. The active staking path keys off
+        // `ArtisanStakeQueue`; this single timestamp is mirrored only so
+        // legacy read-only clients keep seeing a conservative value (the
+        // latest cooldown_end across deposits).
         let mut max_end: u64 = 0;
         for i in 0..queue.len() {
             if let Some(d) = queue.get(i) {
@@ -4217,7 +4290,9 @@ impl EscrowContract {
             env.storage().persistent().set(&queue_key, &remaining);
             Self::extend_persistent(&env, &queue_key);
 
-            // Update deprecated single cooldown to max of remaining
+            // DEPRECATED storage write — see Issue #235. Mirrored only for
+            // legacy clients; active unstake logic above already uses the
+            // queue and never reads this key.
             let mut max_end: u64 = 0;
             for i in 0..remaining.len() {
                 if let Some(d) = remaining.get(i) {
@@ -4245,8 +4320,10 @@ impl EscrowContract {
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&env.current_contract_address(), &artisan, &matured_amount);
 
-        // Track staked funds (#212)
-        Self::update_total_staked(&env, &token, -stake_data.amount);
+        // Track staked funds (#212): the matured amount is the delta
+        // leaving the contract; the per-artisan stake record (if any) is
+        // already kept in sync above.
+        Self::update_total_staked(&env, &token, -matured_amount);
 
         env.events().publish(
             (Symbol::new(&env, "tokens_unstaked"), artisan.clone()),
@@ -4631,14 +4708,22 @@ impl EscrowContract {
         // Validate token whitelist
         Self::check_token_whitelisted(&env, &token);
 
+        // Issue #233: bounded, overflow-safe allocation. Reject once the
+        // counter reaches the cap instead of wrapping into an existing ID.
         let id: u64 = env
             .storage()
             .persistent()
             .get(&DataKey::NextRecurringEscrowId)
             .unwrap_or(1);
+        if id > MAX_RECURRING_ESCROW_ID {
+            env.panic_with_error(crate::Error::RecurringEscrowIdExhausted);
+        }
+        let next_id = id
+            .checked_add(1)
+            .unwrap_or_else(|| env.panic_with_error(crate::Error::RecurringEscrowIdExhausted));
         env.storage()
             .persistent()
-            .set(&DataKey::NextRecurringEscrowId, &(id + 1));
+            .set(&DataKey::NextRecurringEscrowId, &next_id);
         Self::extend_persistent(&env, &DataKey::NextRecurringEscrowId);
 
         let now = env.ledger().timestamp();


### PR DESCRIPTION
## Summary

Bundles four related Soroban storage hygiene fixes plus the minimum patches needed to keep the contract building after a recent merge:

- **#234 — `ReferralRewardBps` deprecation**: writes are now rejected with `Error::DeprecatedFunction`; the getter returns a constant `0` so callers can no longer depend on stale state. The legacy `DataKey` variant is preserved for ABI compatibility only and documented as such.
- **#235 — `StakeCooldownEnd` cleanup**: clarifies in code and docs that the live stake/unstake path operates on `ArtisanStakeQueue` and never reads the legacy single timestamp. Adds admin-only `purge_stake_cooldown_end(artisan)` for opt-in storage cleanup and tags every remaining mirror write as deprecated.
- **#233 — Recurring escrow ID exhaustion**: introduces `MAX_RECURRING_ESCROW_ID` (`u64::MAX - 1`) and replaces the `id + 1` increment with `checked_add` plus a cap check, surfacing the new `Error::RecurringEscrowIdExhausted` instead of wrapping into an existing entry.
- **#244 — `BuyerEscrowCount` / `SellerEscrowCount` scaling**: documents the O(1)-per-account storage shape directly on the `DataKey` variants and in `craft-nexus-contract/docs/deprecated-storage.md`, including why the indexed pattern is preferred over a sparse alternative.

A new `docs/deprecated-storage.md` ties the four tracks together with explicit migration paths and read/write rules.

### Side-effects

Three pre-existing build errors on `main` (introduced by the recent upgradeability merge) were patched as part of this change so the contract still compiles after the new edits:

- `create_unfunded_escrow` was missing the `batch_id` field in its `Escrow` initializer.
- `escrow_from_without_batch` was missing the `funded` field.
- `unstake_tokens` referenced `stake_data.amount` outside its scope when the queue had just been emptied; `update_total_staked` now subtracts `matured_amount`, which is the actual delta leaving the contract.

These are minimum, obvious fixes — happy to break them out into a separate PR if maintainers prefer.

## Test plan

- [ ] `cargo build` succeeds (verified locally).
- [ ] `RUSTFLAGS=\"-C opt-level=z -C lto -C panic=abort\" cargo build --target wasm32-unknown-unknown --release` succeeds and stays under the 64 KB CI cap (verified locally).
- [ ] CI `Build, size check, and test contract` step passes. Note: the existing test suite has a number of unrelated compile breakages on `main` (renamed contract type, removed `mint`/`raise_dispute`/`add_arbitrator` helpers, `with_mut` removed from `Ledger`, etc.) that are out of scope for this PR.
- [ ] Manual review of `docs/deprecated-storage.md` to confirm the migration policy reflects current intent.

closes #233
closes #234
closes #235
closes #244