### PR TITLE
feat: stellar-wave docs and storage optimization (#525, #535, #539, #…

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -830,6 +830,17 @@ impl CraftNexusContract {
         }
     }
 
+    /// Validate an optional IPFS CID string, panicking with `InvalidIpfsHash` if present but invalid.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `ipfs_hash` - Optional CID string to validate
+    ///
+    /// # Errors
+    /// Panics with `Error::InvalidIpfsHash` if the CID is present but fails `validate_ipfs_cid`.
+    ///
+    /// # Storage side-effects
+    /// None — this is a pure validation helper with no storage reads or writes.
     fn validate_optional_ipfs_hash(env: &Env, ipfs_hash: &Option<String>) {
         if let Some(cid) = ipfs_hash {
             if !Self::validate_ipfs_cid(cid) {
@@ -838,6 +849,17 @@ impl CraftNexusContract {
         }
     }
 
+    /// Validate an optional metadata hash, panicking with `InvalidMetadataHash` if present but not 32 bytes.
+    ///
+    /// # Arguments
+    /// * `env` - The contract environment
+    /// * `metadata_hash` - Optional raw bytes to validate
+    ///
+    /// # Errors
+    /// Panics with `Error::InvalidMetadataHash` if the hash is present but its length is not exactly 32 bytes.
+    ///
+    /// # Storage side-effects
+    /// None — this is a pure validation helper with no storage reads or writes.
     fn validate_optional_metadata_hash(env: &Env, metadata_hash: &Option<Bytes>) {
         if let Some(hash) = metadata_hash {
             if hash.len() != 32 {
@@ -1312,7 +1334,8 @@ impl CraftNexusContract {
         let old_min = config.min_release_window;
         config.min_release_window = min_window;
 
-        env.storage().instance().set(&DataKey::PlatformConfig, &config);
+        env.storage().persistent().set(&DataKey::PlatformConfig, &config);
+        Self::extend_persistent(&env, &DataKey::PlatformConfig);
 
         Self::emit_config_updated(
             &env,

--- a/craft-nexus-contract/src/onboarding.rs
+++ b/craft-nexus-contract/src/onboarding.rs
@@ -770,7 +770,18 @@ impl OnboardingContract {
             .set(&DataKey::Username(normalized.clone()), &user);
         Self::extend_persistent(&env, &DataKey::Username(normalized.clone()));
 
-        // Emit event
+        // Emit UserOnboarded event.
+        //
+        // Event topic  : `("UserOnboarded",)`
+        // Event payload: `UserOnboardedEvent { user, username, role }`
+        //
+        // Fields:
+        // * `user`     - The wallet address that was just onboarded.
+        // * `username` - The normalized (lowercased, trimmed) username stored on-chain.
+        // * `role`     - The role assigned: `Buyer` (1) or `Artisan` (2).
+        //
+        // Off-chain indexers should subscribe to this event to build user registries
+        // and trigger downstream workflows (e.g. welcome emails, dashboard provisioning).
         env.events().publish(
             (Symbol::new(&env, "UserOnboarded"),),
             UserOnboardedEvent {
@@ -1275,7 +1286,9 @@ impl OnboardingContract {
             "User not found"
         );
 
-        if Self::is_verification_pending(&env, &user) {
+                Self::extend_persistent(&env, &DataKey::UserProfile(user.clone()));
+
+if Self::is_verification_pending(&env, &user) {
             return;
         }
 


### PR DESCRIPTION

Feature: Stellar Wave — Documentation & Storage Optimization
Closes #525, 
Closes: #535, 
Closes: #539, 
Closes: #541

Changes
#541 — [DOCUMENTATION] src/lib.rs ~line 820

Added comprehensive RustDoc to two private validation helpers that off-chain integrators depend on indirectly:

validate_optional_ipfs_hash — documents the InvalidIpfsHash panic path, accepted input shape, and confirms zero storage side-effects

validate_optional_metadata_hash — documents the InvalidMetadataHash panic path and the 32-byte requirement for SHA-256 commitment hashes

#525 — [DOCUMENTATION] src/onboarding.rs ~line 772

Replaced the bare // Emit event comment in onboard_user with a full structured docblock describing the following:

Event topic: ("UserOnboarded",)

Event payload type: UserOnboardedEvent { user, username, role }

Field-level descriptions for each payload field

Guidance for off-chain indexers on how to consume this event for user registry building and downstream workflow triggers

#539 — [PERFORMANCE] src/lib.rs ~line 1304

Fixed set_min_release_window: it was writing PlatformConfig to instance() storage instead of persistent(), and was missing the extend_persistent TTL refresh call. This meant:

The config write was going to the wrong storage tier (instance storage has different TTL semantics)

No TTL was being extended after the write, risking premature archival

Fixed to use env.storage().persistent().set(...) followed by Self::extend_persistent(...), consistent with every other PlatformConfig write in the contract.

#535 — [PERFORMANCE] src/onboarding.rs ~line 1272

Fixed request_verification: after the .has(&DataKey::UserProfile(...)) existence check, the TTL of the UserProfile entry was never refreshed. Added Self::extend_persistent(&env, &DataKey::UserProfile(user.clone())) immediately after the assert, ensuring the profile entry's TTL is bumped on every verification request — preventing it from expiring during an active verification workflow.

Verification
cargo check passes with 0 errors (all warnings are pre-existing in the codebase)

No behaviour changes to any public function signatures

No snapshot files affected