### PR TITLE
refactor(onboarding,lib): deactivate role payload, get_user docs, fee setter auth ordering, reputation no-op skip

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -1213,6 +1213,16 @@ impl CraftNexusContract {
         successful_delta: u32,
         disputed_delta: u32,
     ) -> bool {
+        // Issue #527 — short-circuit on the no-op call before paying
+        // for the persistent storage read of the onboarding contract
+        // address. If both reputation deltas are 0 the cross-contract
+        // call has no effect; returning `true` here saves a storage
+        // decode + a host `try_invoke_contract` on every escrow
+        // settlement where reputation didn't change.
+        if successful_delta == 0 && disputed_delta == 0 {
+            return true;
+        }
+
         let onboarding = match Self::get_onboarding_address(env) {
             Some(a) => a,
             None => return false,

--- a/craft-nexus-contract/src/onboarding.rs
+++ b/craft-nexus-contract/src/onboarding.rs
@@ -783,13 +783,33 @@ impl OnboardingContract {
         profile
     }
 
-    /// Get user profile by address
+    /// Read-only accessor for a user's profile, keyed by their Stellar
+    /// address.
+    ///
+    /// # Integration notes — issue #529
+    ///
+    /// - This is the canonical "is this address onboarded?" entrypoint
+    ///   for off-chain integrations. It **reverts** with
+    ///   `Error::UserNotFound` if no profile exists for `user`, so
+    ///   callers that want a non-erroring probe should wrap the call
+    ///   with the host's `try_invoke_contract` API and treat the
+    ///   `Err` case as "not onboarded".
+    /// - The returned `UserProfile` carries the user's role, status,
+    ///   verification flag, portfolio CID, and metadata fields needed
+    ///   by the escrow and reputation systems. Treat the response as
+    ///   a snapshot; the profile can be mutated by `update_role`,
+    ///   `deactivate_profile`, `verify_user`, `update_portfolio`, and
+    ///   `change_username`, each of which emits an event indexers
+    ///   can subscribe to instead of polling this function.
+    /// - The function is gas-only (no token movements) so it is safe
+    ///   to call from a simulation / preview path.
     ///
     /// # Arguments
     /// * `user` - User's wallet address
     ///
     /// # Returns
-    /// UserProfile if user exists, reverts otherwise
+    /// `UserProfile` if a profile exists, otherwise panics with
+    /// `Error::UserNotFound`.
     pub fn get_user(env: Env, user: Address) -> UserProfile {
         Self::get_user_profile(&env, user)
     }
@@ -951,10 +971,15 @@ impl OnboardingContract {
             .set(&DataKey::UserProfile(user.clone()), &profile);
         Self::extend_persistent(&env, &DataKey::UserProfile(user.clone()));
 
-        // Emit event
+        // Issue #524 — event payload now carries the user's role at
+        // deactivation time. The role was overwritten in the
+        // `Deactivated` status above, so emitting the captured
+        // `profile.role` here lets an indexer attribute the
+        // deactivation to "an artisan left" vs "a customer left"
+        // without a follow-up profile read.
         env.events().publish(
             (Symbol::new(&env, "ProfileDeactivated"), user.clone()),
-            user,
+            (user, profile.role.clone()),
         );
     }
 
@@ -1603,15 +1628,21 @@ impl OnboardingContract {
 
     /// Set the token used to collect username change fees (admin only).
     pub fn set_username_fee_token(env: Env, token: Address) {
+        // Issue #526 — strict check-effect-interactions ordering.
+        // Load config (read-only) → require_auth(admin) → only then
+        // touch any persistent storage. The previous implementation
+        // called `extend_persistent` on the Config key before the auth
+        // check, so a non-admin caller could spam-extend Config TTL
+        // before being rejected. Matched layout applied to
+        // `set_username_fee_wallet` below.
         let config: OnboardingConfig = env
             .storage()
             .persistent()
             .get(&DataKey::Config)
             .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
-        Self::extend_persistent(&env, &DataKey::Config);
-
         config.platform_admin.require_auth();
 
+        Self::extend_persistent(&env, &DataKey::Config);
         env.storage()
             .persistent()
             .set(&DataKey::UsernameChangeFeeToken, &token);
@@ -1620,15 +1651,16 @@ impl OnboardingContract {
 
     /// Set the wallet that receives username change fees (admin only).
     pub fn set_username_fee_wallet(env: Env, wallet: Address) {
+        // Issue #526 — same ordering as `set_username_fee_token`
+        // above: require_auth runs before any TTL extension or write.
         let config: OnboardingConfig = env
             .storage()
             .persistent()
             .get(&DataKey::Config)
             .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
-        Self::extend_persistent(&env, &DataKey::Config);
-
         config.platform_admin.require_auth();
 
+        Self::extend_persistent(&env, &DataKey::Config);
         env.storage()
             .persistent()
             .set(&DataKey::UsernameChangeFeeWallet, &wallet);


### PR DESCRIPTION
## Summary
Four assigned issues batched into one PR. Each change is small and
scoped to the function the issue body referenced.

closes #524
closes #526
closes #527
closes #529

## Per-issue detail

### closes #524 — \"Implement enhanced business flow requirement #123 for active contracts\"
**File:** `src/onboarding.rs` — `deactivate_profile`.

The `ProfileDeactivated` event was being emitted with only `(user)` in the data slot, so an indexer had to issue a follow-up `get_user` read to find out which role just left the platform. Now emits `(user, profile.role)` — same event topic and gas envelope, indexers can attribute the deactivation to "an artisan left" vs "a customer left" without the extra read.

### closes #526 — \"Audit and protect key endpoint #125 against unauthorized invocation\"
**File:** `src/onboarding.rs` — `set_username_fee_token` and `set_username_fee_wallet`.

The issue body referenced `onboarding.rs:1975`, which is past EOF (the file is 1714 lines on `main`). Audited the admin-only setters and found the same check-effect-interactions ordering issue that #522 already addresses for `set_username_change_fee`: both `set_username_fee_token` and `set_username_fee_wallet` were calling `Self::extend_persistent(&env, &DataKey::Config)` *before* `config.platform_admin.require_auth()`, so a non-admin caller could spam-extend the Config TTL before being rejected. Reordered both functions to `load → require_auth → extend_ttl → persist`. (The matching fix to `set_username_change_fee` is shipping in PR #563 for mawuli's slice of the same batch.)

### closes #527 — \"Optimize storage layout and TTL limits for key index #126\"
**File:** `src/lib.rs` — `safe_update_reputation`.

`safe_update_reputation` was loading the onboarding contract address from persistent storage on every call, then performing a host `try_invoke_contract` — even when both `successful_delta` and `disputed_delta` were zero (which is the common case for an escrow settlement that doesn't shift reputation).

Added an early `(0, 0) → return true` short-circuit at the top of the function. The hot settlement path now skips the persistent decode and the cross-contract call entirely when reputation hasn't changed. Behaviour for non-zero deltas is unchanged.

### closes #529 — \"Document integration interfaces and API parameters for component #128\"
**File:** `src/onboarding.rs` — `get_user`.

`get_user` was the canonical "is this address onboarded?" entrypoint but the doc comment didn't make the contract explicit. Extended the doc comment to spell out:
- That the function reverts with `Error::UserNotFound` (not returns `Option`) and how to non-erroring-probe via `try_invoke_contract`.
- Which fields the returned `UserProfile` carries and which mutating functions can change them (`update_role`, `deactivate_profile`, `verify_user`, `update_portfolio`, `change_username`) — pointed indexers at the per-mutation events so they can subscribe instead of polling.
- That the function is gas-only and safe from simulation / preview paths.

## Verified locally
- `cargo build -p craft-nexus-contract` — clean (47 pre-existing warnings on `main`, none new).

## Honest caveats
- These issues are bulk-templated by the Wave program (identical boilerplate paragraph, line refs that don't all exist — see #526's `:1975` on a 1714-line file). The library itself builds clean on `main` despite the templates' "the codebase is currently in a broken state" footer. `cargo test` does fail with ~135 pre-existing errors on `main`; that's the broken-state the templates were referring to, but it is unrelated to the lib changes here. CI will reflect that pre-existing baseline.
- PR #563 (mawuli's slice) applies the same auth-ordering fix to `set_username_change_fee`. The two PRs touch sibling functions in the same file and may need a small rebase if both are merged in sequence — the conflict is mechanical.