### PR TITLE
perf(storage): indexed escrow IDs and compact verification history

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -240,10 +240,15 @@ pub enum DataKey {
     OnboardingContractAddress,
     /// Map of whitelisted token addresses (Address -> bool); enforcement active when non-empty
     WhitelistedTokens,
-    /// Ordered list of all escrow order IDs ever created (Vec<u32>); used for off-chain enumeration
+    /// DEPRECATED: Legacy monolithic Vec of all escrow order IDs.
+    /// New writes use [`DataKey::GlobalEscrowIdIndexed`] (#515). Kept for
+    /// lazy migration on the next index update or paginated read.
     AllEscrowIds,
-    /// Total count of escrows ever created; lightweight O(1) alternative to AllEscrowIds.len()
+    /// Total count of escrows ever created; O(1) length for indexed enumeration
     EscrowCount,
+    /// Indexed global escrow order ID by creation sequence (#515).
+    /// Each entry stores one `u32` order ID, avoiding Vec rewrites on batch create.
+    GlobalEscrowIdIndexed(u32),
     /// Fallback admin address for recovery if primary admin storage is corrupted (#240)
     FallbackAdmin,
     /// Timestamp when admin recovery mechanism becomes available (time-lock safety)
@@ -1084,57 +1089,48 @@ impl CraftNexusContract {
         env.storage().temporary().remove(&DataKey::ReentryGuard);
     }
 
-    /// Atomically updates both AllEscrowIds and EscrowCount to maintain consistency.
-    /// This function ensures that the count and ID list never diverge, which is critical
-    /// for off-chain enumeration and audit consistency (Issue #226).
+    /// Atomically appends one escrow ID to the indexed global registry and
+    /// increments `EscrowCount` (#515 / Issue #226).
     fn update_escrow_indices_atomic(env: &Env, order_id: u32) {
-        // Update the global escrow ID list
-        let ids_key = DataKey::AllEscrowIds;
-        let mut all_ids: soroban_sdk::Vec<u32> = env
-            .storage()
-            .persistent()
-            .get(&ids_key)
-            .unwrap_or(soroban_sdk::Vec::new(&env));
-        all_ids.push_back(order_id);
-        env.storage().persistent().set(&ids_key, &all_ids);
-        Self::extend_persistent(&env, &ids_key);
+        // Issue #515 — O(1) indexed append replaces monolithic AllEscrowIds Vec
+        // rewrites. Legacy Vec entries are migrated lazily on first touch.
+        Self::migrate_legacy_all_escrow_ids(env);
 
-        // Update the escrow count in lockstep with the ID list
         let count_key = DataKey::EscrowCount;
-        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0u32);
+        let count = Self::get_persistent_u32(env, &count_key);
+
+        let index_key = DataKey::GlobalEscrowIdIndexed(count);
+        env.storage().persistent().set(&index_key, &order_id);
+        Self::extend_persistent(env, &index_key);
+
         env.storage().persistent().set(&count_key, &(count + 1));
-        Self::extend_persistent(&env, &count_key);
+        Self::extend_persistent(env, &count_key);
     }
 
-    /// Atomically updates both AllEscrowIds and EscrowCount for batch operations.
-    /// Ensures all order IDs are added before count is incremented, preventing races.
+    /// Atomically appends escrow IDs to the indexed global registry for batch
+    /// operations (#515). Each ID is stored under its own key so batch creates
+    /// avoid rewriting a growing Vec.
     fn update_escrow_indices_batch_atomic(env: &Env, order_ids: &soroban_sdk::Vec<u32>) {
         if order_ids.is_empty() {
             return;
         }
 
-        // Batch update: add all IDs first
-        let ids_key = DataKey::AllEscrowIds;
-        let mut all_ids: soroban_sdk::Vec<u32> = env
-            .storage()
-            .persistent()
-            .get(&ids_key)
-            .unwrap_or(soroban_sdk::Vec::new(&env));
+        Self::migrate_legacy_all_escrow_ids(env);
+
+        let count_key = DataKey::EscrowCount;
+        let mut count = Self::get_persistent_u32(env, &count_key);
+
         for i in 0..order_ids.len() {
             if let Some(id) = order_ids.get(i) {
-                all_ids.push_back(id);
+                let index_key = DataKey::GlobalEscrowIdIndexed(count);
+                env.storage().persistent().set(&index_key, &id);
+                Self::extend_persistent(env, &index_key);
+                count += 1;
             }
         }
-        env.storage().persistent().set(&ids_key, &all_ids);
-        Self::extend_persistent(&env, &ids_key);
 
-        // Then increment count by the number of IDs added
-        let count_key = DataKey::EscrowCount;
-        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0u32);
-        env.storage()
-            .persistent()
-            .set(&count_key, &(count + order_ids.len() as u32));
-        Self::extend_persistent(&env, &count_key);
+        env.storage().persistent().set(&count_key, &count);
+        Self::extend_persistent(env, &count_key);
     }
 
     // IMPORTANT: this validation is intentionally scoped to escrow creation-time
@@ -1251,6 +1247,50 @@ impl CraftNexusContract {
         env.storage()
             .persistent()
             .extend_ttl(key, TTL_THRESHOLD, TTL_EXTENSION);
+    }
+
+    /// Read a persistent `u32` and extend its TTL when the key exists (#515).
+    fn get_persistent_u32(env: &Env, key: &DataKey) -> u32 {
+        let value = env.storage().persistent().get(key).unwrap_or(0u32);
+        if env.storage().persistent().has(key) {
+            Self::extend_persistent(env, key);
+        }
+        value
+    }
+
+    /// Migrate legacy `AllEscrowIds` Vec storage to indexed keys (#515).
+    fn migrate_legacy_all_escrow_ids(env: &Env) {
+        let legacy_key = DataKey::AllEscrowIds;
+        if !env.storage().persistent().has(&legacy_key) {
+            return;
+        }
+
+        let all_ids: soroban_sdk::Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&legacy_key)
+            .unwrap_or(soroban_sdk::Vec::new(env));
+
+        for i in 0..all_ids.len() {
+            if let Some(id) = all_ids.get(i) {
+                let index_key = DataKey::GlobalEscrowIdIndexed(i);
+                if !env.storage().persistent().has(&index_key) {
+                    env.storage().persistent().set(&index_key, &id);
+                    Self::extend_persistent(env, &index_key);
+                }
+            }
+        }
+
+        let count_key = DataKey::EscrowCount;
+        let stored_count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        if stored_count < all_ids.len() {
+            env.storage()
+                .persistent()
+                .set(&count_key, &(all_ids.len() as u32));
+            Self::extend_persistent(env, &count_key);
+        }
+
+        env.storage().persistent().remove(&legacy_key);
     }
 
     /// Returns the configured maximum release window (in seconds).
@@ -4740,18 +4780,15 @@ impl CraftNexusContract {
     /// `get_all_escrow_ids_iterative` to paginate the full ID set without
     /// hitting Soroban CPU/memory resource limits.
     pub fn get_escrow_count(env: Env) -> u32 {
-        let key = DataKey::EscrowCount;
-        env.storage()
-            .persistent()
-            .get::<DataKey, u32>(&key)
-            .unwrap_or(0)
+        Self::migrate_legacy_all_escrow_ids(&env);
+        Self::get_persistent_u32(&env, &DataKey::EscrowCount)
     }
 
     /// Returns a page of all escrow order IDs created on the platform, in creation order.
     ///
     /// This is the recommended pattern for frontends to enumerate every escrow without
     /// hitting Soroban resource limits. The function reads a bounded slice of the
-    /// globally maintained `AllEscrowIds` index; no on-chain loops proportional to
+    /// indexed `GlobalEscrowIdIndexed` registry; no on-chain loops proportional to
     /// the total escrow count are performed at call time.
     ///
     /// # Usage pattern (frontend / off-chain)
@@ -4768,8 +4805,9 @@ impl CraftNexusContract {
     /// To enumerate storage keys directly via the RPC without calling this function,
     /// use the `getLedgerEntries` method or the experimental `getContractData` cursor
     /// endpoint.  Relevant key patterns:
-    /// - `DataKey::AllEscrowIds`           – the full ordered ID list (this index)
+    /// - `DataKey::GlobalEscrowIdIndexed(index)` – indexed global escrow ID (#515)
     /// - `DataKey::EscrowCount`            – u32 total count
+    /// - `DataKey::AllEscrowIds`           – DEPRECATED legacy Vec index
     /// - `(ESCROW, order_id: u32)`         – individual escrow struct
     /// - `DataKey::BuyerEscrows(address)`  – DEPRECATED: Legacy Vec<u64> of IDs for a buyer
     /// - `DataKey::SellerEscrows(address)` – DEPRECATED: Legacy Vec<u64> of IDs for a seller
@@ -4790,22 +4828,27 @@ impl CraftNexusContract {
             return soroban_sdk::Vec::new(&env);
         }
 
-        let key = DataKey::AllEscrowIds;
-        let all_ids: soroban_sdk::Vec<u32> = env
-            .storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(soroban_sdk::Vec::new(&env));
+        Self::migrate_legacy_all_escrow_ids(&env);
 
+        let total = Self::get_persistent_u32(&env, &DataKey::EscrowCount);
         let start = page * limit;
-        let len = all_ids.len();
 
-        if start >= len {
+        if start >= total {
             return soroban_sdk::Vec::new(&env);
         }
 
-        let end = (start + limit).min(len);
-        all_ids.slice(start..end)
+        let end = (start + limit).min(total);
+        let mut result = soroban_sdk::Vec::new(&env);
+
+        for index in start..end {
+            let index_key = DataKey::GlobalEscrowIdIndexed(index);
+            if let Some(id) = env.storage().persistent().get(&index_key) {
+                result.push_back(id);
+                Self::extend_persistent(&env, &index_key);
+            }
+        }
+
+        result
     }
 
     /// Accept the outstanding partial refund proposal for a disputed escrow.

--- a/craft-nexus-contract/src/onboarding.rs
+++ b/craft-nexus-contract/src/onboarding.rs
@@ -12,6 +12,8 @@ const CURRENT_USER_PROFILE_VERSION: u32 = 4;
 /// Cooldown period for username changes to prevent squatting and rapid identity rotation.
 /// 30 days in seconds.
 const USERNAME_CHANGE_COOLDOWN: u64 = 30 * 24 * 60 * 60;
+/// Maximum verification history entries retained per user (#519).
+const MAX_VERIFICATION_HISTORY: u32 = 10;
 
 #[cfg(test)]
 #[path = "onboarding_test.rs"]
@@ -37,8 +39,13 @@ pub enum DataKey {
     VerificationQueueTail,
     /// Queue index -> address mapping for manual verification requests (#138)
     VerificationQueueIndex(u64),
-    /// Verification history log per user (#63)
+    /// DEPRECATED: Legacy Vec-based verification history (#63).
+    /// Migrated lazily to indexed compact entries (#519).
     VerificationHistory(Address),
+    /// Count of compact verification history entries per user (#519)
+    VerificationHistoryCount(Address),
+    /// Indexed compact verification history entry (#519)
+    VerificationHistoryIndexed(Address, u32),
     /// Username change fee (in stroops) - Issue #114
     UsernameChangeFee,
     /// Token used to collect username change fees (#134)
@@ -138,6 +145,27 @@ pub struct VerificationEntry {
     pub action: String,
     /// Address that performed the action (None for auto-verification)
     pub by: Option<Address>,
+}
+
+/// Compact action code for indexed verification history storage (#519).
+#[contracttype]
+#[derive(Copy, Clone, Eq, PartialEq)]
+#[repr(u32)]
+enum VerificationActionCode {
+    Requested = 0,
+    Approved = 1,
+    Rejected = 2,
+    AutoVerified = 3,
+    UsernameChangedRevoked = 4,
+}
+
+/// Lightweight on-chain verification history entry (#519).
+#[contracttype]
+#[derive(Clone, Eq, PartialEq)]
+struct CompactVerificationEntry {
+    timestamp: u64,
+    action: VerificationActionCode,
+    by: Option<Address>,
 }
 
 /// Contract configuration
@@ -543,10 +571,137 @@ impl OnboardingContract {
 
     fn read_username_fee_wallet(env: &Env, config: &OnboardingConfig) -> Address {
         let key = DataKey::UsernameChangeFeeWallet;
-        env.storage()
+        let wallet = env
+            .storage()
             .persistent()
             .get(&key)
-            .unwrap_or(config.platform_admin.clone())
+            .unwrap_or(config.platform_admin.clone());
+        if env.storage().persistent().has(&key) {
+            Self::extend_persistent(env, &key);
+        }
+        wallet
+    }
+
+    fn read_user_metrics(env: &Env, address: &Address) -> UserMetrics {
+        let key = DataKey::UserMetrics(address.clone());
+        let metrics = env.storage().persistent().get(&key).unwrap_or(UserMetrics {
+            total_escrow_count: 0,
+            total_volume: 0,
+        });
+        if env.storage().persistent().has(&key) {
+            Self::extend_persistent(env, &key);
+        }
+        metrics
+    }
+
+    fn verification_action_to_string(env: &Env, action: VerificationActionCode) -> String {
+        match action {
+            VerificationActionCode::Requested => String::from_str(env, "requested"),
+            VerificationActionCode::Approved => String::from_str(env, "approved"),
+            VerificationActionCode::Rejected => String::from_str(env, "rejected"),
+            VerificationActionCode::AutoVerified => String::from_str(env, "auto_verified"),
+            VerificationActionCode::UsernameChangedRevoked => {
+                String::from_str(env, "username_changed_revoked")
+            }
+        }
+    }
+
+    fn parse_verification_action(env: &Env, action: &String) -> VerificationActionCode {
+        if action == &String::from_str(env, "requested") {
+            VerificationActionCode::Requested
+        } else if action == &String::from_str(env, "approved") {
+            VerificationActionCode::Approved
+        } else if action == &String::from_str(env, "rejected") {
+            VerificationActionCode::Rejected
+        } else if action == &String::from_str(env, "auto_verified") {
+            VerificationActionCode::AutoVerified
+        } else {
+            VerificationActionCode::UsernameChangedRevoked
+        }
+    }
+
+    fn migrate_legacy_verification_history(env: &Env, user: &Address) {
+        let legacy_key = DataKey::VerificationHistory(user.clone());
+        if !env.storage().persistent().has(&legacy_key) {
+            return;
+        }
+
+        let history: Vec<VerificationEntry> = env
+            .storage()
+            .persistent()
+            .get(&legacy_key)
+            .unwrap_or(Vec::new(env));
+
+        let count_key = DataKey::VerificationHistoryCount(user.clone());
+        let mut count: u32 = 0;
+        for i in 0..history.len() {
+            if let Some(entry) = history.get(i) {
+                let compact = CompactVerificationEntry {
+                    timestamp: entry.timestamp,
+                    action: Self::parse_verification_action(env, &entry.action),
+                    by: entry.by.clone(),
+                };
+                let entry_key = DataKey::VerificationHistoryIndexed(user.clone(), i);
+                env.storage().persistent().set(&entry_key, &compact);
+                Self::extend_persistent(env, &entry_key);
+                count = i + 1;
+            }
+        }
+
+        if count > 0 {
+            env.storage().persistent().set(&count_key, &count);
+            Self::extend_persistent(env, &count_key);
+        }
+
+        env.storage().persistent().remove(&legacy_key);
+    }
+
+    fn append_verification_history(
+        env: &Env,
+        user: &Address,
+        action: VerificationActionCode,
+        by: Option<Address>,
+    ) {
+        Self::migrate_legacy_verification_history(env, user);
+
+        let count_key = DataKey::VerificationHistoryCount(user.clone());
+        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+
+        let slot = if count >= MAX_VERIFICATION_HISTORY {
+            for i in 1..MAX_VERIFICATION_HISTORY {
+                let src_key = DataKey::VerificationHistoryIndexed(user.clone(), i);
+                if let Some(entry) = env
+                    .storage()
+                    .persistent()
+                    .get::<DataKey, CompactVerificationEntry>(&src_key)
+                {
+                    let dst_key = DataKey::VerificationHistoryIndexed(user.clone(), i - 1);
+                    env.storage().persistent().set(&dst_key, &entry);
+                    Self::extend_persistent(env, &dst_key);
+                    env.storage().persistent().remove(&src_key);
+                }
+            }
+            MAX_VERIFICATION_HISTORY - 1
+        } else {
+            count
+        };
+
+        let entry = CompactVerificationEntry {
+            timestamp: env.ledger().timestamp(),
+            action,
+            by,
+        };
+        let entry_key = DataKey::VerificationHistoryIndexed(user.clone(), slot);
+        env.storage().persistent().set(&entry_key, &entry);
+        Self::extend_persistent(env, &entry_key);
+
+        let new_count = if count >= MAX_VERIFICATION_HISTORY {
+            MAX_VERIFICATION_HISTORY
+        } else {
+            count + 1
+        };
+        env.storage().persistent().set(&count_key, &new_count);
+        Self::extend_persistent(env, &count_key);
     }
 
     fn collect_username_change_fee(env: &Env, user: &Address, config: &OnboardingConfig) {
@@ -1128,13 +1283,7 @@ impl OnboardingContract {
     /// Get activity metrics for a user.
     /// Returns zeroed metrics if no escrow activity has been recorded yet.
     pub fn get_user_metrics(env: Env, address: Address) -> UserMetrics {
-        env.storage()
-            .persistent()
-            .get::<DataKey, UserMetrics>(&DataKey::UserMetrics(address.clone()))
-            .unwrap_or(UserMetrics {
-                total_escrow_count: 0,
-                total_volume: 0,
-            })
+        Self::read_user_metrics(&env, &address)
     }
 
     /// Increment a user's activity metrics (called by the escrow contract).
@@ -1161,11 +1310,7 @@ impl OnboardingContract {
         }
 
         let key = DataKey::UserMetrics(address.clone());
-        let mut metrics: UserMetrics =
-            env.storage().persistent().get(&key).unwrap_or(UserMetrics {
-                total_escrow_count: 0,
-                total_volume: 0,
-            });
+        let mut metrics = Self::read_user_metrics(&env, &address);
 
         metrics.total_escrow_count = metrics
             .total_escrow_count
@@ -1235,23 +1380,12 @@ impl OnboardingContract {
             env.storage().persistent().set(&profile_key, &profile);
             Self::extend_persistent(env, &profile_key);
 
-            // Append auto-verify entry to history
-            let hist_key = DataKey::VerificationHistory(address.clone());
-            let mut history: Vec<VerificationEntry> = env
-                .storage()
-                .persistent()
-                .get(&hist_key)
-                .unwrap_or(Vec::new(env));
-            history.push_back(VerificationEntry {
-                timestamp: env.ledger().timestamp(),
-                action: String::from_str(env, "auto_verified"),
-                by: None,
-            });
-            if history.len() > 10 {
-                history.remove(0);
-            }
-            env.storage().persistent().set(&hist_key, &history);
-            Self::extend_persistent(env, &hist_key);
+            Self::append_verification_history(
+                env,
+                address,
+                VerificationActionCode::AutoVerified,
+                None,
+            );
 
             env.events()
                 .publish((Symbol::new(env, "UserVerified"),), address);
@@ -1326,23 +1460,12 @@ impl OnboardingContract {
 
         Self::enqueue_verification_request(&env, &user);
 
-        // Append to history
-        let hist_key = DataKey::VerificationHistory(user.clone());
-        let mut history: Vec<VerificationEntry> = env
-            .storage()
-            .persistent()
-            .get(&hist_key)
-            .unwrap_or(Vec::new(&env));
-        history.push_back(VerificationEntry {
-            timestamp: env.ledger().timestamp(),
-            action: String::from_str(&env, "requested"),
-            by: Some(user.clone()),
-        });
-        if history.len() > 10 {
-            history.remove(0);
-        }
-        env.storage().persistent().set(&hist_key, &history);
-        Self::extend_persistent(&env, &hist_key);
+        Self::append_verification_history(
+            &env,
+            &user,
+            VerificationActionCode::Requested,
+            Some(user.clone()),
+        );
     }
 
     /// Approve or reject a pending verification request (admin only).
@@ -1373,24 +1496,17 @@ impl OnboardingContract {
 
         Self::clear_verification_request(&env, &user);
 
-        // Append to history
-        let action = if approve { "approved" } else { "rejected" };
-        let hist_key = DataKey::VerificationHistory(user.clone());
-        let mut history: Vec<VerificationEntry> = env
-            .storage()
-            .persistent()
-            .get(&hist_key)
-            .unwrap_or(Vec::new(&env));
-        history.push_back(VerificationEntry {
-            timestamp: env.ledger().timestamp(),
-            action: String::from_str(&env, action),
-            by: Some(config.platform_admin.clone()),
-        });
-        if history.len() > 10 {
-            history.remove(0);
-        }
-        env.storage().persistent().set(&hist_key, &history);
-        Self::extend_persistent(&env, &hist_key);
+        let action = if approve {
+            VerificationActionCode::Approved
+        } else {
+            VerificationActionCode::Rejected
+        };
+        Self::append_verification_history(
+            &env,
+            &user,
+            action,
+            Some(config.platform_admin.clone()),
+        );
 
         if approve {
             env.events()
@@ -1400,11 +1516,32 @@ impl OnboardingContract {
 
     /// Get the full verification history for a user.
     pub fn get_verification_history(env: Env, user: Address) -> Vec<VerificationEntry> {
-        let hist_key = DataKey::VerificationHistory(user.clone());
-        env.storage()
-            .persistent()
-            .get(&hist_key)
-            .unwrap_or(Vec::new(&env))
+        Self::migrate_legacy_verification_history(&env, &user);
+
+        let count_key = DataKey::VerificationHistoryCount(user.clone());
+        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0);
+        if env.storage().persistent().has(&count_key) {
+            Self::extend_persistent(&env, &count_key);
+        }
+
+        let mut result = Vec::new(&env);
+        for index in 0..count {
+            let entry_key = DataKey::VerificationHistoryIndexed(user.clone(), index);
+            if let Some(compact) = env
+                .storage()
+                .persistent()
+                .get::<DataKey, CompactVerificationEntry>(&entry_key)
+            {
+                result.push_back(VerificationEntry {
+                    timestamp: compact.timestamp,
+                    action: Self::verification_action_to_string(&env, compact.action),
+                    by: compact.by,
+                });
+                Self::extend_persistent(&env, &entry_key);
+            }
+        }
+
+        result
     }
 
     /// Get all addresses currently awaiting manual verification (admin helper).
@@ -1549,11 +1686,11 @@ impl OnboardingContract {
         );
 
         // Enforce cooldown between username changes for the same user.
-        if let Some(last_change) = env
-            .storage()
-            .persistent()
-            .get::<DataKey, u64>(&DataKey::LastUsernameChange(user.clone()))
-        {
+        let cooldown_key = DataKey::LastUsernameChange(user.clone());
+        if let Some(last_change) = env.storage().persistent().get::<DataKey, u64>(&cooldown_key) {
+            if env.storage().persistent().has(&cooldown_key) {
+                Self::extend_persistent(&env, &cooldown_key);
+            }
             let current_time = env.ledger().timestamp();
             assert!(
                 current_time > last_change.saturating_add(USERNAME_CHANGE_COOLDOWN),
@@ -1598,23 +1735,12 @@ impl OnboardingContract {
         );
         Self::extend_persistent(&env, &DataKey::LastUsernameChange(user.clone()));
 
-        // Add history entry for revocation
-        let hist_key = DataKey::VerificationHistory(user.clone());
-        let mut history: Vec<VerificationEntry> = env
-            .storage()
-            .persistent()
-            .get(&hist_key)
-            .unwrap_or(Vec::new(&env));
-        history.push_back(VerificationEntry {
-            timestamp: env.ledger().timestamp(),
-            action: String::from_str(&env, "username_changed_revoked"),
-            by: Some(user.clone()),
-        });
-        if history.len() > 10 {
-            history.remove(0);
-        }
-        env.storage().persistent().set(&hist_key, &history);
-        Self::extend_persistent(&env, &hist_key);
+        Self::append_verification_history(
+            &env,
+            &user,
+            VerificationActionCode::UsernameChangedRevoked,
+            Some(user.clone()),
+        );
 
         // Emit event
         env.events()


### PR DESCRIPTION
## Summary

- Closes #515 — replaces monolithic `AllEscrowIds` Vec appends with O(1) indexed storage (`GlobalEscrowIdIndexed`) and TTL-on-read helpers for escrow enumeration keys.
- Closes #519 — migrates verification history from a heavy `Vec<VerificationEntry>` to compact indexed entries with enum action codes, and adds TTL extension on metrics/username-change read paths.

Both changes use lazy migration so existing on-chain data remains readable without a one-shot migration transaction.

## Changes

### Escrow contract (`lib.rs`) — #515

| Before | After |
|--------|-------|
| Append to `AllEscrowIds` Vec (full rewrite per create/batch) | Write `GlobalEscrowIdIndexed(count)` + increment `EscrowCount` |
| No TTL extend on paginated reads | `get_persistent_u32()` + per-key TTL extend in `get_all_escrow_ids_iterative` |
| — | `migrate_legacy_all_escrow_ids()` removes deprecated Vec on first touch |

### Onboarding contract (`onboarding.rs`) — #519

| Before | After |
|--------|-------|
| `VerificationHistory(Address)` → `Vec<VerificationEntry>` with `String` actions | `VerificationHistoryIndexed(Address, u32)` → `CompactVerificationEntry` with `VerificationActionCode` enum |
| No TTL on `get_user_metrics` / fee wallet reads | `read_user_metrics()` and TTL extend on `LastUsernameChange`, `UsernameChangeFeeWallet` |
| — | `migrate_legacy_verification_history()` for lazy Vec → indexed migration |

## Migration strategy

- **Escrow IDs:** Legacy `AllEscrowIds` is copied to indexed keys on the next create, batch create, or paginated read, then removed.
- **Verification history:** Legacy Vec is copied to indexed compact entries on the next append or `get_verification_history` call, then removed.
- Public return types (`VerificationEntry`, `UserMetrics`, paginated escrow IDs) are unchanged.

## Test plan

- [ ] `cargo check` passes with no warnings
- [ ] `cargo test` — all escrow and onboarding suites pass
- [ ] Update `test_snapshots/` if storage key shapes changed (expected for new indexed keys)
- [ ] `cargo build --target wasm32-unknown-unknown --release` succeeds
- [ ] Verify batch escrow creation no longer writes `AllEscrowIds` in snapshots (should show `GlobalEscrowIdIndexed` instead)
- [ ] Verify verification history tests (`test_verification_history_tracking`) still pass after migration