### PR TITLE
Optimize storage flow and improve contract docs

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -119,6 +119,9 @@ const ADMIN: Symbol = symbol_short!("ADMIN");
 
 /// Standard TTL threshold for persistent storage (approx 14 hours at 5s ledger)
 const TTL_THRESHOLD: u32 = 10_000;
+/// Lower TTL threshold used for hot index reads to reduce the cost of frequent
+/// TTL refresh calls (Issue #533).
+const READ_TTL_THRESHOLD: u32 = 1_000;
 /// Standard TTL extension for persistent storage (approx 30 days)
 const TTL_EXTENSION: u32 = 518_400;
 
@@ -850,7 +853,16 @@ pub struct LegacyUserProfile {
 /// when escrow state changes (release, refund, resolve).
 #[soroban_sdk::contractclient(name = "OnboardingClient")]
 pub trait OnboardingInterface {
+    /// Increment a user's reputation counters.
+    ///
+    /// Called by this escrow contract after a terminal escrow outcome where a
+    /// winner/loser can be determined (release/refund/dispute resolution).
+    /// The onboarding contract authenticates that the caller is the registered
+    /// escrow contract address.
     fn update_reputation(env: Env, address: Address, successful_delta: u32, disputed_delta: u32);
+    /// Increment a user's activity metrics (escrow count + volume).
+    ///
+    /// Used by onboarding to drive auto-verification and analytics counters.
     fn update_user_metrics(
         env: Env,
         address: Address,
@@ -858,12 +870,39 @@ pub trait OnboardingInterface {
         volume_delta: i128,
         token_address: Address,
     );
+    /// Mark a user profile as deactivated.
+    ///
+    /// Used by the escrow contract for administrative safety actions; the
+    /// onboarding contract enforces its own authorization rules.
     fn deactivate_profile(env: Env, user: Address);
+    /// Verify a user, returning the updated profile.
     fn verify_user(env: Env, user: Address) -> UserProfile;
+    /// Return true if the user currently has any active escrow obligations.
     fn has_active_contracts(env: Env, user: Address) -> bool;
+    /// Update onboarding's local active-contract counter for a user.
+    ///
+    /// `delta` should be `+1` when an escrow becomes active and `-1` when the
+    /// escrow closes. The onboarding contract rejects underflows.
+    fn update_active_contracts(env: Env, user: Address, delta: i32);
 }
 
 #[contract]
+/// CraftNexus escrow contract.
+///
+/// # Storage model
+/// - Escrows are stored under `(ESCROW, order_id)` as a single compact record.
+/// - Enumeration uses count + indexed keys (e.g. `EscrowCount` +
+///   `GlobalEscrowIdIndexed(i)`) to avoid unbounded `Vec` growth.
+///
+/// # TTL model
+/// - Persistent entries extend TTL on write via `extend_persistent`.
+/// - Hot index reads use `extend_persistent_read` with a lower threshold to
+///   reduce rent-refresh overhead while still preventing accidental expiry.
+///
+/// # Onboarding integration
+/// - The admin can register an onboarding contract address.
+/// - Cross-contract calls are wrapped in `try_invoke_contract` helpers so an
+///   onboarding failure never bricks escrow settlement.
 pub struct CraftNexusContract;
 
 /// Alias and compatibility layers
@@ -1394,22 +1433,32 @@ impl CraftNexusContract {
             .extend_ttl(key, TTL_THRESHOLD, TTL_EXTENSION);
     }
 
+    fn extend_persistent_read(env: &Env, key: &impl soroban_sdk::IntoVal<Env, soroban_sdk::Val>) {
+        env.storage()
+            .persistent()
+            .extend_ttl(key, READ_TTL_THRESHOLD, TTL_EXTENSION);
+    }
+
     /// Read a persistent `u32` and extend its TTL when the key exists (#515).
     fn get_persistent_u32(env: &Env, key: &DataKey) -> u32 {
-        let value = env.storage().persistent().get(key).unwrap_or(0u32);
-        if env.storage().persistent().has(key) {
-            Self::extend_persistent(env, key);
+        match env.storage().persistent().get(key) {
+            Some(value) => {
+                Self::extend_persistent(env, key);
+                value
+            }
+            None => 0u32,
         }
-        value
     }
 
     fn get_whitelist_count(env: &Env) -> u32 {
         let count_key = DataKey::WhitelistedTokenCount;
-        let count: u32 = env.storage().persistent().get(&count_key).unwrap_or(0u32);
-        if env.storage().persistent().has(&count_key) {
-            Self::extend_persistent(env, &count_key);
+        match env.storage().persistent().get(&count_key) {
+            Some(count) => {
+                Self::extend_persistent(env, &count_key);
+                count
+            }
+            None => 0u32,
         }
-        count
     }
 
     fn set_whitelist_count(env: &Env, count: u32) {
@@ -1533,8 +1582,7 @@ impl CraftNexusContract {
     /// Check if a user has any active escrows or recurring escrows.
     pub fn has_active_escrows(env: Env, user: Address) -> bool {
         let key = DataKey::ActiveObligations(user);
-        let count: u32 = env.storage().persistent().get(&key).unwrap_or(0);
-        count > 0
+        Self::get_persistent_u32(&env, &key) > 0
     }
 
     /// Emit a structured warning event when a cross-contract call to the
@@ -1613,6 +1661,29 @@ impl CraftNexusContract {
             token_address.clone(),
         )
             .into_val(env);
+
+        match env.try_invoke_contract::<(), soroban_sdk::Error>(&onboarding, &method, args) {
+            Ok(Ok(())) => true,
+            _ => {
+                Self::emit_onboarding_call_failed(env, method, onboarding);
+                false
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn safe_update_active_contracts(env: &Env, user: Address, delta: i32) -> bool {
+        if delta == 0 {
+            return true;
+        }
+
+        let onboarding = match Self::get_onboarding_address(env) {
+            Some(a) => a,
+            None => return false,
+        };
+
+        let method = Symbol::new(env, "update_active_contracts");
+        let args: Vec<Val> = (user.clone(), delta).into_val(env);
 
         match env.try_invoke_contract::<(), soroban_sdk::Error>(&onboarding, &method, args) {
             Ok(Ok(())) => true,
@@ -1804,7 +1875,11 @@ impl CraftNexusContract {
         }
 
         let token_key = DataKey::WhitelistedTokenIndexed(token);
-        env.storage().persistent().has(&token_key)
+        let is_whitelisted = env.storage().persistent().has(&token_key);
+        if is_whitelisted {
+            Self::extend_persistent(&env, &token_key);
+        }
+        is_whitelisted
     }
 
     /// Internal helper: panics with TokenNotWhitelisted when enforcement is active
@@ -1833,8 +1908,8 @@ impl CraftNexusContract {
     /// Returns 0 if no tokens are whitelisted (enforcement disabled).
     /// This is more efficient than loading all tokens when only the count is needed.
     pub fn get_whitelisted_token_count(env: Env) -> u32 {
-        let count_key = DataKey::WhitelistedTokenCount;
-        env.storage().persistent().get(&count_key).unwrap_or(0)
+        Self::migrate_legacy_whitelisted_tokens(&env);
+        Self::get_whitelist_count(&env)
     }
 
     /// Migrate legacy whitelist storage to individual key-value pairs.
@@ -2412,6 +2487,9 @@ impl CraftNexusContract {
             .set(&seller_count_key, &(seller_count + 1));
         Self::extend_persistent(&env, &seller_count_key);
 
+        Self::safe_update_active_contracts(&env, buyer.clone(), 1);
+        Self::safe_update_active_contracts(&env, seller.clone(), 1);
+
         // Transfer funds from buyer to contract
         let client = token::Client::new(&env, &token);
         client.transfer(&buyer, &env.current_contract_address(), &amount);
@@ -2531,6 +2609,9 @@ impl CraftNexusContract {
         Self::update_active_obligations(&env, &buyer, 1);
         Self::update_active_obligations(&env, &seller, 1);
 
+        Self::safe_update_active_contracts(&env, buyer.clone(), 1);
+        Self::safe_update_active_contracts(&env, seller.clone(), 1);
+
         Self::emit_escrow_created(
             &env,
             EscrowEvent {
@@ -2607,6 +2688,9 @@ impl CraftNexusContract {
         Self::update_active_obligations(&env, &escrow.buyer, -1);
         Self::update_active_obligations(&env, &escrow.seller, -1);
 
+        Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+        Self::safe_update_active_contracts(&env, escrow.seller.clone(), -1);
+
         Self::exit_reentry_guard(&env);
         Ok(())
     }
@@ -2644,15 +2728,11 @@ impl CraftNexusContract {
                 let index_key = DataKey::BuyerEscrowIndexed(buyer.clone(), storage_index);
                 if let Some(escrow_id) = env.storage().persistent().get::<_, u64>(&index_key) {
                     result.push_back(escrow_id);
-                    env.storage()
-                        .persistent()
-                        .extend_ttl(&index_key, 1000, 518400);
+                    Self::extend_persistent_read(&env, &index_key);
                 }
             }
 
-            env.storage()
-                .persistent()
-                .extend_ttl(&count_key, 1000, 518400);
+            Self::extend_persistent_read(&env, &count_key);
             return Ok(result);
         }
 
@@ -2665,9 +2745,7 @@ impl CraftNexusContract {
             .unwrap_or(soroban_sdk::Vec::new(&env));
 
         if env.storage().persistent().has(&legacy_key) {
-            env.storage()
-                .persistent()
-                .extend_ttl(&legacy_key, 1000, 518400);
+            Self::extend_persistent_read(&env, &legacy_key);
         }
 
         let start = page * limit;
@@ -2723,15 +2801,11 @@ impl CraftNexusContract {
                 let index_key = DataKey::SellerEscrowIndexed(seller.clone(), storage_index);
                 if let Some(escrow_id) = env.storage().persistent().get::<_, u64>(&index_key) {
                     result.push_back(escrow_id);
-                    env.storage()
-                        .persistent()
-                        .extend_ttl(&index_key, 1000, 518400);
+                    Self::extend_persistent_read(&env, &index_key);
                 }
             }
 
-            env.storage()
-                .persistent()
-                .extend_ttl(&count_key, 1000, 518400);
+            Self::extend_persistent_read(&env, &count_key);
             return Ok(result);
         }
 
@@ -2744,9 +2818,7 @@ impl CraftNexusContract {
             .unwrap_or(soroban_sdk::Vec::new(&env));
 
         if env.storage().persistent().has(&legacy_key) {
-            env.storage()
-                .persistent()
-                .extend_ttl(&legacy_key, 1000, 518400);
+            Self::extend_persistent_read(&env, &legacy_key);
         }
 
         let start = page * limit;
@@ -3195,6 +3267,9 @@ impl CraftNexusContract {
         Self::update_active_obligations(&env, &escrow.buyer, -1);
         Self::update_active_obligations(&env, &escrow.seller, -1);
 
+        Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+        Self::safe_update_active_contracts(&env, escrow.seller.clone(), -1);
+
         // Transfer platform fee to platform wallet
         if fee_amount > 0 {
             Self::transfer_platform_fee(&env, &escrow.token, &config.platform_wallet, fee_amount);
@@ -3292,6 +3367,9 @@ impl CraftNexusContract {
         // Decrement active counts
         Self::update_active_obligations(&env, &escrow.buyer, -1);
         Self::update_active_obligations(&env, &escrow.seller, -1);
+
+        Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+        Self::safe_update_active_contracts(&env, escrow.seller.clone(), -1);
 
         // Transfer platform fee to platform wallet
         if fee_amount > 0 {
@@ -3676,6 +3754,9 @@ impl CraftNexusContract {
         Self::update_active_obligations(&env, &escrow.buyer, -1);
         Self::update_active_obligations(&env, &escrow.seller, -1);
 
+        Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+        Self::safe_update_active_contracts(&env, escrow.seller.clone(), -1);
+
         // Refund to buyer
         let client = token::Client::new(&env, &escrow.token);
         client.transfer(
@@ -3965,6 +4046,9 @@ impl CraftNexusContract {
         // Clean up any orphaned partial refund proposal
         let proposal_key = DataKey::PartialRefundProposal(order_id);
         env.storage().persistent().remove(&proposal_key);
+
+        Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+        Self::safe_update_active_contracts(&env, escrow.seller.clone(), -1);
 
         // Now perform token transfers (external calls)
         match resolution {
@@ -4640,9 +4724,7 @@ impl CraftNexusContract {
                 let escrow_opt: Option<Escrow> =
                     env.storage().persistent().get(&(ESCROW, order_id));
                 if escrow_opt.is_some() {
-                    env.storage()
-                        .persistent()
-                        .extend_ttl(&(ESCROW, order_id), 1000, 518400);
+                    Self::extend_persistent_read(&env, &(ESCROW, order_id));
                 }
 
                 if let Some(mut escrow) = escrow_opt {
@@ -4661,6 +4743,9 @@ impl CraftNexusContract {
                     // Decrement active counts
                     Self::update_active_obligations(&env, &escrow.buyer, -1);
                     Self::update_active_obligations(&env, &escrow.seller, -1);
+
+                    Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+                    Self::safe_update_active_contracts(&env, escrow.seller.clone(), -1);
 
                     // Transfer platform fee to platform wallet
                     if fee_amount > 0 {
@@ -4860,6 +4945,9 @@ impl CraftNexusContract {
         // Decrement active counts
         Self::update_active_obligations(&env, &escrow.buyer, -1);
         Self::update_active_obligations(&env, &escrow.seller, -1);
+
+        Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+        Self::safe_update_active_contracts(&env, escrow.seller.clone(), -1);
 
         // Now perform token transfers (external calls)
         let token_client = token::Client::new(&env, &escrow.token);
@@ -5467,6 +5555,9 @@ impl CraftNexusContract {
         Self::update_active_obligations(&env, &escrow.buyer, -1);
         Self::update_active_obligations(&env, &escrow.seller, -1);
 
+        Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+        Self::safe_update_active_contracts(&env, escrow.seller.clone(), -1);
+
         // CEI Pattern: INTERACTIONS - External calls AFTER state updates
         let token_client = token::Client::new(&env, &escrow.token);
 
@@ -5644,6 +5735,9 @@ impl CraftNexusContract {
         Self::update_active_obligations(&env, &buyer, 1);
         Self::update_active_obligations(&env, &artisan, 1);
 
+        Self::safe_update_active_contracts(&env, buyer.clone(), 1);
+        Self::safe_update_active_contracts(&env, artisan.clone(), 1);
+
         // Lock funds upfront
         let token_client = token::Client::new(&env, &token);
         token_client.transfer(&buyer, &env.current_contract_address(), &total_amount);
@@ -5721,7 +5815,8 @@ impl CraftNexusContract {
         escrow.current_cycle += 1;
         escrow.last_release_time = now;
 
-        if escrow.current_cycle == escrow.duration as u64 {
+        let became_inactive = escrow.current_cycle == escrow.duration as u64;
+        if became_inactive {
             escrow.is_active = false;
             // Decrement active recurring counts
             Self::update_active_obligations(&env, &escrow.buyer, -1);
@@ -5730,6 +5825,11 @@ impl CraftNexusContract {
 
         env.storage().persistent().set(&key, &escrow);
         Self::extend_persistent(&env, &key);
+
+        if became_inactive {
+            Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+            Self::safe_update_active_contracts(&env, escrow.artisan.clone(), -1);
+        }
 
         env.events().publish(
             (Symbol::new(&env, "recurring_escrow"), id),
@@ -5800,6 +5900,9 @@ impl CraftNexusContract {
         // Decrement active recurring counts
         Self::update_active_obligations(&env, &escrow.buyer, -1);
         Self::update_active_obligations(&env, &escrow.artisan, -1);
+
+        Self::safe_update_active_contracts(&env, escrow.buyer.clone(), -1);
+        Self::safe_update_active_contracts(&env, escrow.artisan.clone(), -1);
 
         // CEI Pattern: INTERACTIONS - External calls AFTER state updates
         if remaining > 0 {

--- a/craft-nexus-contract/src/onboarding.rs
+++ b/craft-nexus-contract/src/onboarding.rs
@@ -59,6 +59,13 @@ pub enum DataKey {
     UsernameChangeFeeWallet,
     /// Timestamp of last username change per user - Issue #114
     LastUsernameChange(Address),
+    /// Count of currently-active contracts for a user, maintained by the
+    /// configured escrow contract (Issue #533).
+    ///
+    /// This key lets onboarding flows validate "active contract" constraints
+    /// (e.g. preventing deactivation) without needing a cross-contract call
+    /// back into the escrow contract on every check.
+    ActiveContractCount(Address),
 }
 
 /// User roles in the CraftNexus platform
@@ -247,6 +254,8 @@ pub enum Error {
     InvalidPortfolioCid = 13,
     /// Cooldown period not yet elapsed
     CooldownActive = 14,
+    /// Attempted to decrement active contract count below zero
+    ActiveContractUnderflow = 15,
 }
 
 #[soroban_sdk::contractclient(name = "EscrowClient")]
@@ -574,6 +583,14 @@ fn validate_ipfs_cid(cid: &String) -> bool {
 }
 
 #[contract]
+/// CraftNexus onboarding contract.
+///
+/// This contract owns the user onboarding registry (profiles + usernames) and
+/// exposes integration endpoints used by the escrow contract to:
+/// - Update reputation counters (`update_reputation`)
+/// - Update activity metrics (`update_user_metrics`)
+/// - Maintain the active-contract counter used for business rules
+///   (`update_active_contracts`)
 pub struct OnboardingContract;
 
 #[contractimpl]
@@ -1414,6 +1431,12 @@ impl OnboardingContract {
             .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
         Self::extend_persistent(&env, &DataKey::Config);
 
+        let local_key = DataKey::ActiveContractCount(user.clone());
+        if let Some(count) = env.storage().persistent().get::<_, u32>(&local_key) {
+            Self::extend_persistent(&env, &local_key);
+            return count > 0;
+        }
+
         if let Some(escrow_contract) = config.escrow_contract {
             let client = EscrowClient::new(&env, &escrow_contract);
             client.has_active_escrows(&user)
@@ -1636,6 +1659,14 @@ impl OnboardingContract {
         let normalized = normalize_username(&env, &profile.username);
         if normalized == String::from_str(&env, "admin") {
             env.panic_with_error(Error::Unauthorized);
+        }
+
+        let local_key = DataKey::ActiveContractCount(user.clone());
+        if let Some(count) = env.storage().persistent().get::<_, u32>(&local_key) {
+            Self::extend_persistent(&env, &local_key);
+            if count > 0 {
+                env.panic_with_error(Error::ActiveEscrowsExist);
+            }
         }
 
         // Check for active escrows via cross-contract call if available
@@ -2081,6 +2112,81 @@ impl OnboardingContract {
         if config.auto_verify_enabled {
             Self::try_auto_verify(&env, &address, &config, &metrics);
         }
+    }
+
+    /// Update a user's "active contracts" counter (called by the escrow contract).
+    ///
+    /// This endpoint provides a lightweight, upgrade-safe way for the escrow
+    /// contract to signal that a user has entered or exited an active escrow
+    /// lifecycle. The onboarding contract uses the counter to enforce business
+    /// rules such as "profiles with active escrows cannot be deactivated"
+    /// without making a cross-contract read on every check.
+    ///
+    /// # Authorization
+    /// - Requires auth from `OnboardingConfig::escrow_contract` when configured.
+    /// - Falls back to `platform_admin` auth when no escrow contract is registered.
+    ///
+    /// # Storage side-effects
+    /// - Reads and extends TTL on `DataKey::Config`.
+    /// - Reads/writes and extends TTL on `DataKey::ActiveContractCount(user)`.
+    /// - Extends TTL (if present) on `DataKey::UserProfile(user)` and
+    ///   `DataKey::UserMetrics(user)` so active users do not silently fall out of
+    ///   onboarding state due to key expiry between settlements.
+    ///
+    /// # Arguments
+    /// * `user` - User participating in the active contract lifecycle
+    /// * `delta` - Signed increment: `+1` when a contract becomes active, `-1`
+    ///   when it is closed. Other values are allowed but should be used with
+    ///   caution; underflows revert with `Error::ActiveContractUnderflow`.
+    ///
+    /// # Reverts if
+    /// - Contract not initialized
+    /// - Caller is not the registered escrow contract (or admin fallback)
+    /// - `delta` would underflow the active counter
+    pub fn update_active_contracts(env: Env, user: Address, delta: i32) {
+        if delta == 0 {
+            return;
+        }
+
+        let config: OnboardingConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Config)
+            .unwrap_or_else(|| env.panic_with_error(Error::NotInitialized));
+        Self::extend_persistent(&env, &DataKey::Config);
+
+        match config.escrow_contract {
+            Some(ref escrow_addr) => escrow_addr.require_auth(),
+            None => config.platform_admin.require_auth(),
+        }
+
+        let key = DataKey::ActiveContractCount(user.clone());
+        let current = env.storage().persistent().get::<_, u32>(&key).unwrap_or(0u32);
+        if env.storage().persistent().has(&key) {
+            Self::extend_persistent(&env, &key);
+        }
+
+        let next = if delta > 0 {
+            current.saturating_add(delta as u32)
+        } else {
+            let subtract = (-delta) as u32;
+            if subtract > current {
+                env.panic_with_error(Error::ActiveContractUnderflow);
+            }
+            current - subtract
+        };
+
+        if next == 0 {
+            if env.storage().persistent().has(&key) {
+                env.storage().persistent().remove(&key);
+            }
+        } else {
+            env.storage().persistent().set(&key, &next);
+            Self::extend_persistent(&env, &key);
+        }
+
+        Self::extend_persistent_if_present(&env, &DataKey::UserProfile(user.clone()));
+        Self::extend_persistent_if_present(&env, &DataKey::UserMetrics(user));
     }
 
     /// Internal helper: verify a user automatically if they meet the configured thresholds.

--- a/craft-nexus-contract/src/onboarding_test.rs
+++ b/craft-nexus-contract/src/onboarding_test.rs
@@ -1489,6 +1489,74 @@ fn test_has_active_contracts() {
 }
 
 #[test]
+fn test_update_active_contracts_tracks_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_test(&env);
+    let user = Address::generate(&env);
+    client.onboard_user(&user, &String::from_str(&env, "tracked"), &UserRole::Buyer);
+
+    let escrow_id = env.register_contract(None, crate::CraftNexusContract);
+    let platform_wallet = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+    let escrow_client = crate::CraftNexusContractClient::new(&env, &escrow_id);
+    escrow_client.initialize(
+        &platform_wallet,
+        &admin,
+        &arbitrator,
+        &500,
+        &Some(client.address.clone()),
+    );
+    client.set_escrow_contract(&escrow_id);
+
+    client.update_active_contracts(&user, &1);
+    assert!(client.has_active_contracts(&user));
+
+    let auths = env.auths();
+    assert!(auths.iter().any(|(addr, _)| addr == &escrow_id));
+
+    client.update_active_contracts(&user, &-1);
+    assert!(!client.has_active_contracts(&user));
+}
+
+#[test]
+#[should_panic]
+fn test_update_active_contracts_underflow_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_test(&env);
+    let user = Address::generate(&env);
+    client.onboard_user(&user, &String::from_str(&env, "underflow"), &UserRole::Buyer);
+
+    let escrow_id = env.register_contract(None, crate::CraftNexusContract);
+    client.set_escrow_contract(&escrow_id);
+
+    let _ = admin;
+    client.update_active_contracts(&user, &-1);
+}
+
+#[test]
+#[should_panic]
+fn test_deactivate_profile_rejects_active_contract_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let (client, admin) = setup_test(&env);
+    let user = Address::generate(&env);
+    client.onboard_user(&user, &String::from_str(&env, "deact"), &UserRole::Buyer);
+
+    let escrow_id = env.register_contract(None, crate::CraftNexusContract);
+    client.set_escrow_contract(&escrow_id);
+
+    client.update_active_contracts(&user, &1);
+    client.deactivate_profile(&user);
+
+    let _ = admin;
+}
+
+#[test]
 #[should_panic]
 fn test_get_verification_queue_unauthorized() {
     let env = Env::default();

--- a/craft-nexus-contract/src/scalability_test.rs
+++ b/craft-nexus-contract/src/scalability_test.rs
@@ -609,3 +609,16 @@ fn test_artisan_stake_queue_max_capacity() {
     // We can't use std::panic::catch_unwind in no_std, so we'll just verify the count
     // In a real scenario, this would panic with StakeQueueFull error
 }
+
+#[test]
+fn test_index_read_budget_smoke() {
+    let (env, client, buyer, seller, token, _, _, _) = setup_test();
+    client.create_escrow(&buyer, &seller, &token, &1000, &1, &Some(604800));
+
+    env.budget().reset_default();
+    let before = env.budget().cpu_instruction_count();
+    let _ = client.has_active_escrows(&buyer);
+    let after = env.budget().cpu_instruction_count();
+
+    assert!(before > after);
+}


### PR DESCRIPTION
## Summary
This PR delivers an MVP-ready, Soroban-best-practice update across performance, feature flow, and integration documentation:

- **[PERFORMANCE]** Reduced persistent TTL refresh overhead for hot index reads and ensured TTL refresh on read for key indices.
- **[FEATURE]** Implemented an enhanced “active contracts” business flow between the escrow and onboarding contracts (upgrade-safe + lightweight).
- **[DOCUMENTATION]** Added/expanded RustDoc integration notes for key public interfaces in `src/onboarding.rs` and `src/lib.rs`.
- **[TESTS]** Added coverage for active-contract transitions, underflow protection, and a lightweight budget smoke check.

## Key Changes

### 1) Storage + TTL optimization (Escrow contract)
- Added `READ_TTL_THRESHOLD` and centralized TTL refresh for hot reads via `extend_persistent_read`.
- Refactored selected persistent reads to extend TTL only when the key exists via `Option`-based reads (avoids `has()` + `get()` double access patterns).
- Ensured whitelist and active-obligation reads refresh TTL when present to prevent silent expiration of hot state.

Files:
- `craft-nexus-contract/src/lib.rs`

### 2) Enhanced business flow: Active contracts
Introduced a lightweight active-contract counter in onboarding to support “active escrow” business rules without requiring cross-contract reads in every onboarding check.

- Added onboarding storage key: `DataKey::ActiveContractCount(Address)`
- Added onboarding endpoint: `update_active_contracts(user, delta)`
  - Auth: escrow-contract-only when configured; otherwise admin fallback (consistent with existing onboarding integration rules)
  - Safety: prevents underflow (`Error::ActiveContractUnderflow`)
  - Storage/TTL: updates `ActiveContractCount` and bumps TTL for relevant keys when present
- Updated onboarding’s `has_active_contracts` and `deactivate_profile` to consult the local counter first, falling back to escrow cross-contract checks when needed.
- Updated escrow → onboarding integration interface to include `update_active_contracts`, and escrow settlement/creation paths to call the safe wrapper:
  - `safe_update_active_contracts` uses `try_invoke_contract` and never bricks escrow flows on onboarding issues.

Files:
- `craft-nexus-contract/src/onboarding.rs`
- `craft-nexus-contract/src/lib.rs`

### 3) Integration documentation improvements
- Added/expanded RustDoc for:
  - Onboarding contract purpose and integration endpoints
  - Escrow contract storage/TTL model and onboarding safety model
  - Cross-contract interface additions (`OnboardingInterface`)

Files:
- `craft-nexus-contract/src/onboarding.rs`
- `craft-nexus-contract/src/lib.rs`

### 4) Tests + lightweight benchmarking smoke
- Added onboarding tests for:
  - Correct tracking of active contract count
  - Underflow protection
  - Deactivation rejection when active count is non-zero
- Added a lightweight “budget smoke” check in scalability tests (instruction counter monotonicity).

Files:
- `craft-nexus-contract/src/onboarding_test.rs`
- `craft-nexus-contract/src/scalability_test.rs`

## Security / CEI Notes
- Preserves **check-effects-interactions** ordering:
  - Escrow state mutations occur before token transfers/callback-like interactions.
  - Cross-contract calls to onboarding remain “safe” (`try_invoke_contract`) and do not trap/brick escrow flows.
- Active-contract counter updates are performed as part of the escrow flow but remain non-fatal if onboarding is misconfigured or fails.

## Backward Compatibility
- Existing onboarding profile versioning remains unchanged (`CURRENT_USER_PROFILE_VERSION` untouched).
- Legacy onboarding behavior is preserved:
  - If `ActiveContractCount` is not present, onboarding still falls back to the escrow contract `has_active_escrows` call.
- Storage migrations were not required for profile structures.

## How to Test
Run:
- `cargo test`
- `cargo doc --no-deps`

## Notes
- This PR intentionally keeps the implementation minimal and upgrade-safe:
  - The onboarding-side active-contract counter is a compact `u32` entry per user.
  - TTL refresh changes focus on reducing duplicated reads and lowering refresh threshold cost for hot index reads.
  
  
  
  ## Related Issues
Closes #455 
Closes #456 
Closes #457 
Closes #461 