### PR TITLE
test(onboarding): preserve profile status across idempotent retries

### DIFF
--- a/craft-nexus-contract/src/enhanced_features_test.rs
+++ b/craft-nexus-contract/src/enhanced_features_test.rs
@@ -164,6 +164,22 @@ fn test_profile_deactivation_success() {
 }
 
 #[test]
+fn test_onboarding_retry_preserves_deactivated_status() {
+    let env = Env::default();
+    let (_, onboarding, buyer, _, _, _, _, _) = setup_enhanced_test(&env);
+
+    onboarding.deactivate_profile(&buyer);
+    let active_count = onboarding.get_active_user_count();
+
+    let retried =
+        onboarding.onboard_user(&buyer, &String::from_str(&env, "buyer"), &UserRole::Buyer);
+
+    assert_eq!(retried.status, ProfileStatus::Deactivated);
+    assert_eq!(onboarding.get_active_user_count(), active_count);
+    assert!(!onboarding.is_username_taken(&String::from_str(&env, "buyer")));
+}
+
+#[test]
 #[should_panic]
 fn test_profile_deactivation_fails_with_active_traditional_escrow() {
     let env = Env::default();

--- a/craft-nexus-contract/src/onboarding.rs
+++ b/craft-nexus-contract/src/onboarding.rs
@@ -60,9 +60,10 @@
 //! - `UserVerified`, `UsernameChanged`, and `PortfolioUpdated` carry only the
 //!   address; fetch the current value via [`OnboardingContract::get_user`] when
 //!   the new field value is needed.
-//! - `UserOnboarded` is emitted exactly once per address — a second
-//!   `onboard_user` call for the same address panics with
-//!   [`Error::AlreadyOnboarded`] and emits nothing.
+//! - `UserOnboarded` is emitted exactly once per address. An identical
+//!   `onboard_user` retry returns the canonical profile and repairs missing
+//!   secondary state without emitting another event. A retry with a different
+//!   username or role panics with [`Error::AlreadyOnboarded`] (#929).
 //!
 //! ## Cross-contract interface
 //!
@@ -3110,7 +3111,8 @@ impl OnboardingContract {
     /// # Errors (panic)
     /// * [`Error::NotInitialized`] — `initialize` has not been called.
     /// * [`Error::InvalidRole`] — `role` is not `Buyer` or `Artisan`.
-    /// * [`Error::AlreadyOnboarded`] — the address already has a profile.
+    /// * [`Error::AlreadyOnboarded`] — the address already has a profile with a
+    ///   different username or role.
     /// * [`Error::UsernameTaken`] — the normalized username is in use.
     /// * [`Error::UsernameTooShort`] / [`Error::UsernameTooLong`].
     pub fn onboard_user(env: Env, user: Address, username: String, role: UserRole) -> UserProfile {


### PR DESCRIPTION
Closes #929

## Problem

Retried or interrupted onboarding requests must not create a second profile, increment active-user accounting twice, reclaim a released username unexpectedly, or change an existing profile status.

## Summary

- Rebases the PR work onto the current `main` history and removes the stale merge-conflict payload.
- Documents the canonical retry behavior now implemented by onboarding: identical retries return the account-keyed profile and repair missing secondary state; retries with a different username or role are rejected.
- Adds regression coverage proving that retrying onboarding for a deactivated profile preserves `ProfileStatus::Deactivated`.
- Verifies that the retry does not increment `active_user_count` or reclaim the released username.

## Behavior covered

- Duplicate identical submissions are safely merged through the canonical account-keyed profile.
- Conflicting identity submissions remain rejected with `AlreadyOnboarded`.
- Missing username and state-revision indexes are repaired by the existing idempotent path.
- Deactivated profiles stay deactivated across retries.
- `UserOnboarded` remains a once-per-address event.

## Test plan

- [x] `rustfmt --edition 2021 --config skip_children=true --check craft-nexus-contract/src/onboarding.rs craft-nexus-contract/src/enhanced_features_test.rs`
- [x] `git diff --check`
- [ ] `cargo test test_onboarding_retry_preserves_deactivated_status` — currently blocked by pre-existing unresolved conflict markers committed on `main` in `craft-nexus-contract/src/lib.rs` and `craft-nexus-contract/src/test.rs`; the Rust parser fails before tests start.

## Scope and risk

This is a focused regression-test and documentation update. It does not change contract storage layout, public entrypoint signatures, error codes, or runtime onboarding logic.