### PR TITLE
feat(contract): add resource-aware model verification for batch continuations (#1146)

### DIFF
--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -37,6 +37,8 @@ mod test;
 mod pagination_boundary_test;
 #[cfg(test)]
 mod prop_test;
+#[cfg(test)]
+mod resource_aware_test;
 
 // Onboarding is a separate logical contract; only one `#[contract]` may be linked per WASM
 // artifact. Keep it in this crate for host tests (`cargo test`) but omit from guest builds.
@@ -45,6 +47,9 @@ pub mod onboarding;
 
 /// Centralized pagination input validation (Issue #1022).
 pub mod pagination_validation;
+
+/// Resource-aware model for batch-escrow continuations (Issue #1146).
+pub mod resource_model;
 
 /// Error codes grouped by category for off-chain triage.
 ///
@@ -266,6 +271,10 @@ pub enum Error {
     /// Requested WASM upgrade cooldown is below `MIN_WASM_UPGRADE_COOLDOWN`,
     /// which would let the mandatory review window be bypassed (#1062).
     UpgradeCooldownTooShort = 83,
+    /// The estimated resource footprint (CPU / memory / storage writes) of a
+    /// scheduled-continuation chunk exceeds the configured continuation budget.
+    /// No state is mutated when this is returned (Issue #1146).
+    ResourceLimitExceeded = 84,
 }
 
 /// Returns `true` if the error is transient and the operation may succeed on retry.
@@ -566,6 +575,10 @@ pub enum DataKey {
     WasmUpgradeProposal,
     /// Configurable maximum release window (in seconds)
     MaxReleaseWindow,
+    /// Admin-configurable estimated CPU ceiling (in host instruction units) that
+    /// a single scheduled-continuation chunk may spend before any escrow is
+    /// mutated. Guards over-budget continuations before funds move (Issue #1146).
+    ContinuationResourceBudget,
     /// Address of the deployed onboarding contract for cross-contract reputation calls
     OnboardingContractAddress,
     /// DEPRECATED legacy storage: Map of whitelisted token addresses (Address -> bool).
@@ -2984,6 +2997,39 @@ impl CraftNexusContract {
     pub fn get_min_release_window(env: Env) -> u32 {
         let config = Self::get_platform_config_internal(&env);
         config.min_release_window
+    }
+
+    /// Get the configured continuation resource budget (host CPU instructions)
+    /// for a single `continue_batch_escrow` chunk, or the default when unset.
+    pub fn get_continuation_resource_budget(env: Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ContinuationResourceBudget)
+            .unwrap_or(resource_model::DEFAULT_CONTINUATION_CPU_BUDGET)
+    }
+
+    /// Set the estimated CPU ceiling (host instruction units) a single
+    /// `continue_batch_escrow` chunk may consume (admin only).
+    ///
+    /// Continuation chunks whose [`resource_model`] estimate exceeds this
+    /// budget are rejected with `Error::ResourceLimitExceeded` **before** any
+    /// escrow is created or funds move, so the job cursor stays put.
+    ///
+    /// # Panics
+    /// - If the caller is not the admin.
+    /// - If `budget` is below `MIN_CONTINUATION_CPU_BUDGET` (prevents an
+    ///   accidental zeroing of the scheduler).
+    pub fn set_continuation_resource_budget(env: Env, budget: u64) {
+        let config = Self::get_platform_config_internal(&env);
+        config.admin.require_auth();
+
+        if budget < resource_model::MIN_CONTINUATION_CPU_BUDGET {
+            env.panic_with_error(crate::Error::ResourceLimitExceeded);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::ContinuationResourceBudget, &budget);
     }
 
     /// Register the deployed OnboardingContract address so the escrow contract
@@ -8535,6 +8581,16 @@ impl CraftNexusContract {
                 chunk.push_back(entry);
             }
         }
+
+        // Resource-aware gateway (Issue #1146): before this chunk mutates any
+        // escrow or moves funds, assert that its estimated resource footprint
+        // fits within the configured continuation budget. If it does not, we
+        // reject the chunk *before* mutation so the job cursor and all balances
+        // are left untouched, and the caller can retry with a smaller chunk or
+        // raise the budget.
+        let budget = Self::get_continuation_resource_budget(&env);
+        let estimate = resource_model::estimate_create_chunk(&env, &chunk);
+        resource_model::ensure_chunk_within_budget(&estimate, Some(budget))?;
 
         // The existing batch function commits the whole chunk atomically. If
         // it fails, this job cursor is not advanced.

--- a/craft-nexus-contract/src/resource_aware_test.rs
+++ b/craft-nexus-contract/src/resource_aware_test.rs
@@ -1,0 +1,265 @@
+#![cfg(test)]
+
+//! Resource-Aware Model Verification (Issue #1146).
+//!
+//! These tests exercise the three acceptance criteria of the resource-aware
+//! model added in `resource_model.rs`:
+//!
+//! 1. **Over-budget operations are rejected before mutation.** A continuation
+//!    chunk whose estimated resource footprint exceeds the configured budget is
+//!    rejected with `Error::ResourceLimitExceeded` *before* any escrow is
+//!    created or funds move: the job cursor stays put and no escrow exists.
+//! 2. **Resumed execution matches one-shot semantics.** Scheduling and fully
+//!    resuming a batch through `continue_batch_escrow` yields exactly the same
+//!    escrows (order IDs, amounts) as a single `create_escrows_batch` call.
+//! 3. **Resource assumptions hold under worst-case record sizes.** A full
+//!    work-limit chunk whose records carry the maximum IPFS CID and 32-byte
+//!    hashes stays within the default Soroban ledger budget.
+
+use super::*;
+use resource_model::{self, BatchResourceEstimate};
+use soroban_sdk::{
+    testutils::Address as _,
+    token, Address, Env,
+};
+
+/// Shared fixture mirroring the other test modules.
+fn setup_test() -> (
+    Env,
+    EscrowContractClient<'static>,
+    Address,
+    Address,
+    Address,
+    Address,
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.budget().reset_unlimited();
+
+    let contract_id = env.register_contract(None, CraftNexusContract);
+    let client = EscrowContractClient::new(&env, &contract_id);
+
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let platform_wallet = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let arbitrator = Address::generate(&env);
+    let token_admin = Address::generate(&env);
+    let onboarding = Address::generate(&env);
+
+    let token_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_addr = token_id.address();
+    let token_asset = token::StellarAssetClient::new(&env, &token_addr);
+    token_asset.mint(&buyer, &1_000_000_000);
+
+    client.initialize(&platform_wallet, &admin, &arbitrator, &500, &Some(onboarding));
+    client.set_min_escrow_amount(&token_addr, &0);
+    client.set_min_release_window(&1);
+
+    (env, client, buyer, seller, token_addr, admin)
+}
+
+/// Build `n` escrow-create params. `worst_case` pads each record with the
+/// longest *valid* IPFS CID and 32-byte optional hashes.
+fn build_params(
+    env: &Env,
+    buyer: &Address,
+    seller: &Address,
+    token: &Address,
+    n: u32,
+    offset: u32,
+    worst_case: bool,
+) -> soroban_sdk::Vec<EscrowCreateParams> {
+    let mut params = soroban_sdk::Vec::new(env);
+    // A valid CIDv1 base32lower CID of ~100 chars (prefix 'b', payload [a-z2-7]).
+    // This is the longest payload `validate_ipfs_cid` accepts, so it exercises the
+    // worst-case record size while still passing validation.
+    let cid = format!("b{}", "a".repeat(99));
+    let hash = soroban_sdk::Bytes::from_array(env, &[0xAB; 32]);
+    for i in 0..n {
+        params.push_back(EscrowCreateParams {
+            buyer: buyer.clone(),
+            seller: seller.clone(),
+            token: token.clone(),
+            amount: 1_000,
+            order_id: offset + i + 1,
+            release_window: Some(3_600),
+            ipfs_hash: if worst_case {
+                Some(soroban_sdk::String::from_str(env, &cid))
+            } else {
+                None
+            },
+            metadata_hash: if worst_case { Some(hash.clone()) } else { None },
+            service_agreement_hash: if worst_case {
+                Some(hash.clone())
+            } else {
+                None
+            },
+        });
+    }
+    params
+}
+
+// ── Criterion 1: over-budget rejected before mutation ────────────────────────
+
+#[test]
+fn over_budget_continuation_is_rejected_before_mutation() {
+    let (env, client, buyer, seller, token, _admin) = setup_test();
+
+    let params = build_params(&env, &buyer, &seller, &token, 5, 1_000, false);
+    let job_id = client.schedule_batch_escrow(&buyer, &params);
+
+    // A budget that is below the estimated cost of even a single escrow makes
+    // every continuation over budget. The setter is admin-gated.
+    client.set_continuation_resource_budget(&2_000_000);
+    assert_eq!(client.get_continuation_resource_budget(), 2_000_000);
+
+    let result = client.try_continue_batch_escrow(&job_id, &buyer, &5);
+    assert!(
+        matches!(result, Err(Ok(Error::ResourceLimitExceeded))),
+        "expected ResourceLimitExceeded, got {:?}",
+        result
+    );
+
+    // Cursor must not have advanced...
+    let progress = client.get_batch_escrow_progress(&job_id).unwrap();
+    assert_eq!(progress.next_index, 0);
+    assert_eq!(progress.status, BatchJobStatus::Pending);
+
+    // ...no escrow may exist (nothing mutated, no funds moved)...
+    assert!(client.try_get_escrow(&1_001).is_err());
+    assert!(client.try_get_escrow(&1_005).is_err());
+}
+
+#[test]
+fn over_budget_rejection_leaves_balances_untouched() {
+    let (env, client, buyer, seller, token, _admin) = setup_test();
+
+    let token_client = token::Client::new(&env, &token);
+    let balance_before = token_client.balance(&buyer);
+    let params = build_params(&env, &buyer, &seller, &token, 5, 2_000, false);
+    let job_id = client.schedule_batch_escrow(&buyer, &params);
+
+    client.set_continuation_resource_budget(&1_000_000);
+    let result = client.try_continue_batch_escrow(&job_id, &buyer, &5);
+    assert!(matches!(result, Err(Ok(Error::ResourceLimitExceeded))));
+
+    let balance_after = token_client.balance(&buyer);
+    assert_eq!(
+        balance_before, balance_after,
+        "buyer balance must not change when a continuation is rejected"
+    );
+}
+
+// ── Criterion 2: resumed execution matches one-shot semantics ────────────────
+
+#[test]
+fn resumed_execution_matches_one_shot_semantics() {
+    // One-shot path (its own env / client).
+    let (env_one, client_one, buyer_one, seller_one, token_one, _) = setup_test();
+    let one_shot_params = build_params(&env_one, &buyer_one, &seller_one, &token_one, 12, 3_000, false);
+    let one_shot_ids = client_one.create_escrows_batch(&one_shot_params);
+
+    // Scheduled + resumed path (separate env / client).
+    let (env_two, client_two, buyer_two, seller_two, token_two, _) = setup_test();
+    let scheduled_params = build_params(&env_two, &buyer_two, &seller_two, &token_two, 12, 3_000, false);
+    let job_id = client_two.schedule_batch_escrow(&buyer_two, &scheduled_params);
+
+    // Resume in 5,5,2 chunks (MAX_BATCH_WORK_LIMIT = 5).
+    let p1 = client_two.continue_batch_escrow(&job_id, &buyer_two, &5);
+    assert_eq!(p1.next_index, 5);
+    let p2 = client_two.continue_batch_escrow(&job_id, &buyer_two, &5);
+    assert_eq!(p2.next_index, 10);
+    let p3 = client_two.continue_batch_escrow(&job_id, &buyer_two, &2);
+    assert_eq!(p3.next_index, 12);
+    assert_eq!(p3.status, BatchJobStatus::Completed);
+
+    // Both paths created escrows for the exact same order IDs and amounts.
+    assert_eq!(one_shot_ids.len(), 12);
+    for i in 0..12u32 {
+        let order_id = 3_001 + i;
+        let resumed = client_two.get_escrow(&order_id);
+        let one = client_one.get_escrow(&order_id);
+        assert_eq!(resumed.amount, one.amount, "order {} amount mismatch", order_id);
+    }
+}
+
+// ── Criterion 3: worst-case record sizes stay within budget ──────────────────
+
+#[test]
+fn worst_case_records_stay_within_default_budget() {
+    let (env, client, buyer, seller, token, _) = setup_test();
+
+    let params = build_params(
+        &env,
+        &buyer,
+        &seller,
+        &token,
+        pagination_validation::MAX_BATCH_WORK_LIMIT,
+        4_000,
+        true,
+    );
+    let job_id = client.schedule_batch_escrow(&buyer, &params);
+
+    // Default continuation budget must admit a full worst-case work chunk.
+    let est = client.get_continuation_resource_budget();
+    assert!(est >= resource_model::DEFAULT_CONTINUATION_CPU_BUDGET);
+
+    // Reset to the *default* ledger budget so a breach aborts the test loudly.
+    env.budget().reset_default();
+    let result = client.try_continue_batch_escrow(&job_id, &buyer, &pagination_validation::MAX_BATCH_WORK_LIMIT);
+    match result {
+        Ok(Ok(progress)) => assert_eq!(progress.next_index, pagination_validation::MAX_BATCH_WORK_LIMIT),
+        Ok(Err(e)) => panic!("worst-case continuation returned error: {:?}", e),
+        Err(_) => panic!("worst-case continuation exceeded the default ledger budget"),
+    }
+}
+
+// ── Model unit checks (pure, no ledger) ──────────────────────────────────────
+
+#[test]
+fn model_estimate_scales_with_cid_size() {
+    let small = resource_model::estimate_single_escrow_cpu(0);
+    let large = resource_model::estimate_single_escrow_cpu(resource_model::MAX_IPFS_CID_LEN);
+    assert!(large > small);
+    assert_eq!(
+        resource_model::estimate_single_escrow_cpu(10_000),
+        large,
+        "cid length must be clamped to the model maximum"
+    );
+}
+
+#[test]
+fn model_estimate_carries_footprint_counts() {
+    let env = Env::default();
+    let buyer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let token = Address::generate(&env);
+
+    // Known CID length (10 chars) so the expected CPU is exact.
+    let cid = soroban_sdk::String::from_str(&env, "baaaaaaaaa");
+    let mut params = soroban_sdk::Vec::new(&env);
+    for i in 0..4u32 {
+        params.push_back(EscrowCreateParams {
+            buyer: buyer.clone(),
+            seller: seller.clone(),
+            token: token.clone(),
+            amount: 1_000,
+            order_id: i,
+            release_window: Some(3_600),
+            ipfs_hash: Some(cid.clone()),
+            metadata_hash: None,
+            service_agreement_hash: None,
+        });
+    }
+
+    let est = resource_model::estimate_create_chunk(&env, &params);
+    let per_record = resource_model::estimate_single_escrow_cpu(10);
+    let expected: BatchResourceEstimate = BatchResourceEstimate {
+        est_cpu_insns: 4 * per_record,
+        est_storage_writes: 4 * resource_model::PER_ESCROW_STORAGE_WRITES,
+        est_ttl_extends: 4 * resource_model::PER_ESCROW_TTL_EXTENDS,
+        est_events: 4 * resource_model::PER_ESCROW_EVENTS,
+    };
+    assert_eq!(est, expected);
+}

--- a/craft-nexus-contract/src/resource_model.rs
+++ b/craft-nexus-contract/src/resource_model.rs
@@ -1,0 +1,244 @@
+//! Resource-Aware Model for batch-escrow continuations (Issue #1146).
+//!
+//! Soroban enforces a per-transaction resource envelope (CPU instructions,
+//! memory bytes, footprint entries) that, when exceeded, aborts the whole
+//! invocation *after* any partial work has been performed. For resumable
+//! batch creation this is dangerous: a continuation chunk that processes N
+//! escrows one-by-one could mutate (fund) the first K escrows and only then
+//! run out of budget, leaving the job cursor behind and the batch in a
+//! half-applied state.
+//!
+//! To close that gap we maintain an explicit, deterministic resource model.
+//! Every escrow creation is annotated with a conservative estimate of the
+//! host resources it will consume (base CPU + per-byte CPU for the variable
+//! length payload, footprint writes, TTL extends, and emitted events). Before
+//! a continuation chunk is allowed to mutate any escrow we sum the estimates
+//! for that chunk and compare them against an admin-configurable ceiling. If
+//! the chunk is over budget we reject it with [`crate::Error::ResourceLimitExceeded`]
+//! **before** any state change, so the job cursor and all balances remain
+//! untouched. The caller may then retry with a smaller chunk or raise the
+//! budget.
+//!
+//! # Model guarantees
+//!
+//! 1. **Over-budget rejection precedes mutation.** `estimate_create_chunk`
+//!    is evaluated by [`crate::CraftNexusContract::continue_batch_escrow`]
+//!    before `create_batch_escrow` is invoked, so no escrow is created, no
+//!    funds move, and the persisted cursor is not advanced when the chunk is
+//!    rejected.
+//! 2. **Worst-case sizing.** The per-record estimate uses the maximum allowed
+//!    record payloads (a 128-byte IPFS CID plus two 32-byte hashes), so the
+//!    model is a strict upper bound on a well-formed request.
+//! 3. **One-shot equivalence.** Because each chunk is created through the same
+//!    `create_batch_escrow` path as a one-shot batch, a fully resumed job
+//!    yields exactly the escrows a single-shot call would. The model only
+//!    adds a pre-flight gating step; it never changes chunking semantics.
+
+use crate::{EscrowCreateParams, Error};
+use soroban_sdk::{Env, Vec};
+
+// ---------------------------------------------------------------------------
+// Network budget baseline (documented, conservative model constants)
+// ---------------------------------------------------------------------------
+
+/// Maximum length in characters of an IPFS CID accepted by the contract
+/// (see `validate_ipfs_cid`, lib.rs). Used to size the worst-case record.
+pub const MAX_IPFS_CID_LEN: u32 = 128;
+/// Fixed size in bytes of the canonical metadata / service-agreement hashes.
+pub const OPTIONAL_HASH_LEN: u32 = 32;
+
+/// Lower bound on the estimated CPU cost (host instruction units) to create a
+/// single escrow with the *minimum* variable-length payload. This covers the
+/// onboarding state checks, escrow record construction, token transfer /
+/// audit bookkeeping, and the two triggerable storage index updates.
+pub const PER_ESCROW_BASE_CPU_INSNS: u64 = 2_400_000;
+/// Marginal CPU (host instruction units) attributed per byte of the variable
+/// length IPFS CID stored on the escrow record. Captures the extra
+/// encode/decode and footprint cost of larger records (Issue #1146).
+pub const PER_CID_BYTE_CPU_INSNS: u64 = 2_000;
+
+/// Number of persistent storage writes conservatively attributed to one escrow
+/// creation inside a batch (escrow record + buyer/seller index + batch-wide
+/// count + global index accounting).
+pub const PER_ESCROW_STORAGE_WRITES: u64 = 12;
+/// Number of TTL extension host calls conservatively attributed to one escrow
+/// creation inside a batch.
+pub const PER_ESCROW_TTL_EXTENDS: u64 = 8;
+/// Number of `EscrowEvent` events emitted per escrow creation.
+pub const PER_ESCROW_EVENTS: u64 = 1;
+
+/// Admin-configurable ceiling used by default when no explicit budget has been
+/// set. Chosen conservatively: five worst-case records (128-byte CIDs) are
+/// estimated at `5 * (2.4e6 + 128 * 2e3) = 13.28e6` instruction units, so the
+/// default leaves headroom while staying comfortably below the ~100e6
+/// protocol transaction ceiling.
+pub const DEFAULT_CONTINUATION_CPU_BUDGET: u64 = 20_000_000;
+
+/// The smallest budget an admin may configure. Prevents a zeroing attack that
+/// would silently disable every continuation.
+pub const MIN_CONTINUATION_CPU_BUDGET: u64 = 1_000_000;
+
+// ---------------------------------------------------------------------------
+// Estimate type
+// ---------------------------------------------------------------------------
+
+/// A deterministic, conservative estimate of the host resources a batch chunk
+/// will consume when created through `create_batch_escrow`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BatchResourceEstimate {
+    /// Estimated host CPU instructions.
+    pub est_cpu_insns: u64,
+    /// Estimated persistent storage writes.
+    pub est_storage_writes: u64,
+    /// Estimated TTL extension host calls.
+    pub est_ttl_extends: u64,
+    /// Estimated number of emitted events.
+    pub est_events: u64,
+}
+
+impl BatchResourceEstimate {
+    /// True when the estimate is within the given CPU budget.
+    #[inline]
+    pub fn fits_within_cpu_budget(&self, cpu_budget: u64) -> bool {
+        self.est_cpu_insns <= cpu_budget
+    }
+}
+
+/// Compute the worst-case CPU estimate for a single `EscrowCreateParams`.
+///
+/// The payload size is the IPFS CID length clamped to the contract's maximum;
+/// the two optional 32-byte hashes are constant size so they are folded into
+/// the base cost.
+#[inline]
+pub fn estimate_single_escrow_cpu(cid_len: u32) -> u64 {
+    let cid_len = cid_len.min(MAX_IPFS_CID_LEN);
+    PER_ESCROW_BASE_CPU_INSNS + u64::from(cid_len).saturating_mul(PER_CID_BYTE_CPU_INSNS)
+}
+
+/// Estimate the resources a scheduled batch chunk will consume when its
+/// escrows are created. `params` is the exact chunk (`job.params[i]` for
+/// `i in [next_index, next_index + work_limit)`).
+///
+/// This is a pure, side-effect free computation: it performs no storage reads
+/// or writes, so it is safe to run on the continuation boundary before any
+/// mutation.
+pub fn estimate_create_chunk(
+    _env: &Env,
+    params: &Vec<EscrowCreateParams>,
+) -> BatchResourceEstimate {
+    let mut est_cpu_insns: u64 = 0;
+    let mut n: u64 = 0;
+    for i in 0..params.len() {
+        if let Some(p) = params.get(i) {
+            let cid_len = match &p.ipfs_hash {
+                Some(cid) => cid.len(),
+                None => 0,
+            };
+            est_cpu_insns = est_cpu_insns.saturating_add(estimate_single_escrow_cpu(cid_len));
+            n = n.saturating_add(1);
+        }
+    }
+    BatchResourceEstimate {
+        est_cpu_insns,
+        est_storage_writes: n.saturating_mul(PER_ESCROW_STORAGE_WRITES),
+        est_ttl_extends: n.saturating_mul(PER_ESCROW_TTL_EXTENDS),
+        est_events: n.saturating_mul(PER_ESCROW_EVENTS),
+    }
+}
+
+/// Centralised budget resolution / validation used by the continuation path.
+///
+/// `configured` is the estimate of the immediate chunk's CPU cost (call
+/// [`estimate_create_chunk`] first). `budget` is the admin-configured ceiling,
+/// falling back to [`DEFAULT_CONTINUATION_CPU_BUDGET`] when `None`.
+///
+/// Returns `Ok(())` when the chunk fits and `Err(Error::ResourceLimitExceeded)`
+/// when it does not. Callers must invoke this **before** any state mutation.
+pub fn ensure_chunk_within_budget(
+    estimate: &BatchResourceEstimate,
+    budget: Option<u64>,
+) -> Result<(), Error> {
+    let budget = budget.unwrap_or(DEFAULT_CONTINUATION_CPU_BUDGET);
+    if estimate.fits_within_cpu_budget(budget) {
+        Ok(())
+    } else {
+        Err(Error::ResourceLimitExceeded)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn estimate_uses_worst_case_cid_clamped_to_max() {
+        let tiny = estimate_single_escrow_cpu(0);
+        let max = estimate_single_escrow_cpu(MAX_IPFS_CID_LEN);
+        let over_max = estimate_single_escrow_cpu(10_000);
+
+        assert!(max > tiny);
+        assert_eq!(max, over_max, "cid length must be clamped to the max");
+    }
+
+    #[test]
+    fn estimate_never_flags_an_empty_chunk() {
+        let env = Env::default();
+        let params = Vec::new(&env);
+        let est = estimate_create_chunk(&env, &params);
+        assert_eq!(est.est_cpu_insns, 0);
+        assert!(ensure_chunk_within_budget(&est, Some(1)).is_ok());
+    }
+
+    #[test]
+    fn default_budget_accepts_maximum_work_chunk() {
+        let env = Env::default();
+        let mut params = Vec::new(&env);
+        // Longest valid base32lower CID (~100 chars) models the worst-case
+        // realistic record size for a full work-limit chunk.
+        let cid = format!("b{}", "a".repeat(99));
+        for i in 0..5u32 {
+            params.push_back(EscrowCreateParams {
+                buyer: soroban_sdk::Address::generate(&env),
+                seller: soroban_sdk::Address::generate(&env),
+                token: soroban_sdk::Address::generate(&env),
+                amount: 1_000,
+                order_id: i,
+                release_window: Some(3_600),
+                ipfs_hash: Some(soroban_sdk::String::from_str(&env, &cid)),
+                metadata_hash: None,
+                service_agreement_hash: None,
+            });
+        }
+        let est = estimate_create_chunk(&env, &params);
+        assert!(ensure_chunk_within_budget(&est, None).is_ok());
+    }
+
+    #[test]
+    fn over_budget_estimate_is_rejected() {
+        let env = Env::default();
+        let mut params = Vec::new(&env);
+        for i in 0..5u32 {
+            params.push_back(EscrowCreateParams {
+                buyer: soroban_sdk::Address::generate(&env),
+                seller: soroban_sdk::Address::generate(&env),
+                token: soroban_sdk::Address::generate(&env),
+                amount: 1_000,
+                order_id: i,
+                release_window: Some(3_600),
+                ipfs_hash: None,
+                metadata_hash: None,
+                service_agreement_hash: None,
+            });
+        }
+        let est = estimate_create_chunk(&env, &params);
+        let tiny_budget = est.est_cpu_insns / 2;
+        assert_eq!(
+            ensure_chunk_within_budget(&est, Some(tiny_budget)),
+            Err(Error::ResourceLimitExceeded)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1146 — Add Resource-Aware Model Verification.

This change introduces an explicit, deterministic **resource model** for the
resumable batch-escrow scheduler so that a scheduled continuation chunk is
gated **before** any escrow is created or any funds move. Soroban aborts the
whole invocation when a transaction exceeds its resource envelope, which for a
continuation could otherwise leave a job cursor behind a half-applied batch
(first K escrows funded, cursor not advanced). The model closes that gap.

## What I changed

### New module: `src/resource_model.rs`
- Annotates every escrow creation with a conservative host-resource estimate
  (base CPU + per-byte CPU for the variable-length IPFS CID, plus footprint
  storage writes, TTL extends, and emitted events), sized for **worst-case**
  record payloads (max valid IPFS CID + two 32-byte hashes).
- `estimate_create_chunk` → `BatchResourceEstimate`, a pure, side-effect-free
  computation safe to run at the continuation boundary.
- `ensure_chunk_within_budget` → resolves a configurable CPU ceiling and
  returns `Error::ResourceLimitExceeded` when the chunk is over budget.
- Documented model constants (`DEFAULT_CONTINUATION_CPU_BUDGET`,
  `MIN_CONTINUATION_CPU_BUDGET`, per-record costs).

### `src/lib.rs`
- New error variant `Error::ResourceLimitExceeded (84)`.
- New data key `DataKey::ContinuationResourceBudget` (admin-configurable).
- New admin functions `get_continuation_resource_budget` /
  `set_continuation_resource_budget`.
- `continue_batch_escrow` now evaluates the resource estimate **before**
  invoking `create_batch_escrow`, so an over-budget chunk is rejected before
  any mutation: the job cursor is left untouched and no balances change.

### New tests: `src/resource_aware_test.rs`
Covers the three acceptance criteria end-to-end:
1. **Over-budget operations rejected before mutation** — a low configured
   budget makes `continue_batch_escrow` return `ResourceLimitExceeded`, the
   cursor stays at `0 / Pending`, no escrow exists, and the buyer's balance is
   unchanged.
2. **Resumed execution matches one-shot semantics** — a 12-record batch
   resumed in `5,5,2` chunks produces exactly the same escrows (order IDs,
   amounts) as a single `create_escrows_batch` call.
3. **Worst-case record sizes** — a full work-limit chunk carrying max-length
   IPFS CIDs and 32-byte hashes stays within the default Soroban ledger budget.

## Acceptance criteria

- [x] Over-budget operations are rejected before mutation (`continue_batch_escrow` gates pre-mutation).
- [x] Resumed execution matches one-shot semantics where allowed (regression test).
- [x] Resource assumptions tested under worst-case record sizes (CI-budget test).

## Files modified

- `craft-nexus-contract/src/lib.rs`
- `craft-nexus-contract/src/resource_model.rs` (new)
- `craft-nexus-contract/src/resource_aware_test.rs` (new)

## Verification

I could not run `cargo` in this environment (Rust toolchain not installed), so
please run the standard checklist locally/CI before merge:

```bash
cd craft-nexus-contract
cargo check --tests
cargo test --lib resource
cargo build --target wasm32v1-none --release
```

## Notes for reviewers

- The resource guard is intentionally scoped to the **continuation** path
  (chunk ≤ `MAX_BATCH_WORK_LIMIT = 5`) and not the one-shot `create_batch_escrow`
  path, so existing one-shot batches of up to `MAX_BATCH_SIZE = 20` are
  unaffected. The continuation budget is admin-tunable and floor-guarded
  (`MIN_CONTINUATION_CPU_BUDGET`) to avoid an accidental zeroing of the scheduler.
- The CPU constants are conservative model parameters (documented in
  `resource_model.rs`); they act as a deterministic safety gate, with the
  protocol budget still enforced by the host as a backstop.
