### PR TITLE
feat(contract): make batch operations explicitly bounded (#1074)

### DIFF
--- a/craft-nexus-contract/docs/ERROR_CATALOG.md
+++ b/craft-nexus-contract/docs/ERROR_CATALOG.md
@@ -340,13 +340,28 @@ This document catalogs all public contract errors, their meanings, triggering co
 **Description**: Batch operation exceeds the maximum allowed size.
 
 **Triggering Conditions**:
-- Batch size > `MAX_BATCH_SIZE (50)`
+- Batch item count > the configured batch size limit (default `20`; admin can
+  change via `set_batch_size_limit`)
 - Rate limit exceeded (disputes)
 
 **Suggested Client Action**:
-1. Reduce batch size to ≤ 50
+1. Reduce batch size to the configured limit
 2. Use scheduled batch for larger operations
 3. Implement pagination with `schedule_batch_escrow()`
+
+---
+
+#### Error 87: BatchResourceLimitExceeded
+**Description**: A batch call's expected storage work exceeds the configured
+batch resource budget (Issue #1074).
+
+**Triggering Conditions**:
+- `expected_storage_writes(batch_size) >` the configured batch resource budget
+- The batch is rejected **before** any escrow is created or funds move
+
+**Suggested Client Action**:
+1. Reduce the batch's item count
+2. Ask the admin to raise the budget via `set_batch_resource_budget`
 
 ---
 

--- a/craft-nexus-contract/src/batch_bounds.rs
+++ b/craft-nexus-contract/src/batch_bounds.rs
@@ -1,0 +1,164 @@
+//! Configurable bounds for batch escrow operations (Issue #1074).
+//!
+//! Batch methods must reject work sizes that exceed the configured contract
+//! resource budgets **before** any escrow is created or any token moves.
+//! Soroban aborts the whole invocation when its resource envelope
+//! (instructions, footprint entries, TTL extends) is breached, but only after
+//! the budget has actually been burnt. Rejecting a batch *before* mutation is
+//! cheaper, deterministic, and gives callers a clean error instead of a host
+//! abort.
+//!
+//! This module centralises the two explicitly-bounded axes introduced by
+//! Issue #1074:
+//!
+//! 1. **Item-count ceiling** – the maximum number of escrows a single batch
+//!    call may carry. Configurable per contract via
+//!    [`crate::CraftNexusContract::set_batch_size_limit`]; defaults to the
+//!    legacy `MAX_BATCH_SIZE` ceiling.
+//! 2. **Expected storage-work ceiling** – a conservative estimate of the
+//!    persistent storage writes a batch will perform (escrow record, buyer /
+//!    seller indexes, batch counter and global index accounting). Configurable
+//!    per contract via
+//!    [`crate::CraftNexusContract::set_batch_resource_budget`].
+//!
+//! [`ensure_batch_within_bounds`] is a pure, side-effect-free pre-flight check:
+//! it performs no storage reads or writes, so it is safe to run on every batch
+//! boundary (one-shot creation, schedule, and continuations) before any
+//! mutation. When it rejects a request, the error is returned *before* state
+//! changes and the caller may retry with a smaller batch or ask the admin to
+//! raise the configured limit / budget.
+
+use crate::Error;
+
+// ---------------------------------------------------------------------------
+// Configurable bounds (documented defaults / floors / ceilings)
+// ---------------------------------------------------------------------------
+
+/// Default maximum number of escrows accepted per batch call.
+///
+/// Kept in lockstep with the legacy [`crate::MAX_BATCH_SIZE`] constant so the
+/// out-of-the-box behaviour of valid batches is unchanged. Only admins can
+/// raise or lower it through
+/// [`crate::CraftNexusContract::set_batch_size_limit`].
+pub const DEFAULT_BATCH_SIZE_LIMIT: u32 = crate::MAX_BATCH_SIZE;
+
+/// Floor for the configurable batch size limit. Prevents a misconfiguration
+/// that would silently disable batch creation entirely.
+pub const MIN_BATCH_SIZE_LIMIT: u32 = 1;
+
+/// Protocol ceiling for the configurable batch size limit. Keeps any single
+/// batch call inside the Soroban ledger-entry envelope; raising the item-count
+/// limit alone does **not** relax the storage-work budget below.
+pub const MAX_BATCH_SIZE_LIMIT: u32 = 100;
+
+/// Conservative estimate of the persistent storage writes required to create a
+/// single escrow inside a batch (escrow record, buyer/seller indexed entries,
+/// batch-wide counter, and global index accounting).
+pub const STORAGE_WRITES_PER_ESCROW: u64 = 12;
+
+/// Default ceiling for the expected storage work of a single batch call.
+///
+/// Sized to admit a full, default-sized batch (`20 * 12 = 240` writes) so that
+/// existing valid batches keep working, while remaining far below the protocol
+/// footprint envelope to leave headroom for TTL extends and emitted events.
+/// Admins can tighten this ceiling (or raise it together with the item-count
+/// limit) through [`crate::CraftNexusContract::set_batch_resource_budget`].
+pub const DEFAULT_BATCH_STORAGE_WRITES_BUDGET: u64 =
+    u64::from(DEFAULT_BATCH_SIZE_LIMIT).saturating_mul(STORAGE_WRITES_PER_ESCROW);
+
+/// Floor for the configurable storage-work budget: at least one escrow's worth
+/// of work must always be admitted so a misconfiguration cannot disable batch
+/// creation.
+pub const MIN_BATCH_STORAGE_WRITES_BUDGET: u64 = STORAGE_WRITES_PER_ESCROW;
+
+// ---------------------------------------------------------------------------
+// Expected-work estimation (pure, no ledger access)
+// ---------------------------------------------------------------------------
+
+/// Estimate the expected storage work (persistent writes) of a batch call that
+/// carries `item_count` escrows.
+#[inline]
+pub fn expected_storage_writes(item_count: u32) -> u64 {
+    u64::from(item_count).saturating_mul(STORAGE_WRITES_PER_ESCROW)
+}
+
+/// Reject a batch whose work size exceeds the configured bounds, **before**
+/// any state mutation.
+///
+/// Checks, in order:
+/// 1. `item_count > size_limit` → `Err(Error::BatchLimitExceeded)`.
+/// 2. `expected_storage_writes(item_count) > storage_budget` →
+///    `Err(Error::BatchResourceLimitExceeded)`.
+///
+/// The empty batch (`item_count == 0`) always passes, mirroring the existing
+/// empty-batch fast path.
+pub fn ensure_batch_within_bounds(
+    item_count: u32,
+    size_limit: u32,
+    storage_budget: u64,
+) -> Result<(), Error> {
+    if item_count > size_limit {
+        return Err(Error::BatchLimitExceeded);
+    }
+    if expected_storage_writes(item_count) > storage_budget {
+        return Err(Error::BatchResourceLimitExceeded);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests (pure, no ledger)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_batch_is_never_rejected() {
+        assert!(ensure_batch_within_bounds(0, MIN_BATCH_SIZE_LIMIT, 0).is_ok());
+        assert_eq!(expected_storage_writes(0), 0);
+    }
+
+    #[test]
+    fn defaults_admit_a_full_default_size_batch() {
+        assert!(ensure_batch_within_bounds(
+            DEFAULT_BATCH_SIZE_LIMIT,
+            DEFAULT_BATCH_SIZE_LIMIT,
+            DEFAULT_BATCH_STORAGE_WRITES_BUDGET,
+        )
+        .is_ok());
+        assert!(ensure_batch_within_bounds(
+            DEFAULT_BATCH_SIZE_LIMIT + 1,
+            DEFAULT_BATCH_SIZE_LIMIT,
+            u64::MAX,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn oversized_item_count_is_rejected() {
+        assert_eq!(
+            ensure_batch_within_bounds(6, 5, u64::MAX),
+            Err(Error::BatchLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn over_budget_expected_storage_work_is_rejected() {
+        // 5 escrows * 12 writes = 60; a 48-write budget must reject already.
+        assert_eq!(
+            ensure_batch_within_bounds(5, 100, 48),
+            Err(Error::BatchResourceLimitExceeded)
+        );
+    }
+
+    #[test]
+    fn expected_storage_work_scales_with_item_count() {
+        assert_eq!(expected_storage_writes(1), STORAGE_WRITES_PER_ESCROW);
+        assert_eq!(
+            expected_storage_writes(20),
+            20 * STORAGE_WRITES_PER_ESCROW
+        );
+    }
+}

--- a/craft-nexus-contract/src/lib.rs
+++ b/craft-nexus-contract/src/lib.rs
@@ -46,6 +46,14 @@ pub mod onboarding;
 /// Centralized pagination input validation (Issue #1022).
 pub mod pagination_validation;
 
+/// Explicit bounds for batch operations (Issue #1074).
+///
+/// Batch methods validate item counts and expected storage work against
+/// admin-configurable ceilings *before* any financial mutation, so oversized
+/// requests are rejected deterministically instead of failing mid-loop against
+/// the Soroban resource envelope.
+pub mod batch_bounds;
+
 /// Error codes grouped by category for off-chain triage.
 ///
 /// # Categories
@@ -272,6 +280,11 @@ pub enum Error {
     /// An active dispute, recurring escrow, or pending upgrade exists that blocks
     /// the requested emergency operation from starting (#1072).
     EmergencyConflictActive = 86,
+    /// The estimated storage work (persistent writes) of a batch call exceeds
+    /// the configured batch resource budget. No escrow is created and no funds
+    /// move when this is returned: the batch is rejected *before* state changes
+    /// start (Issue #1074).
+    BatchResourceLimitExceeded = 87,
 }
 
 /// Returns `true` if the error is transient and the operation may succeed on retry.
@@ -572,6 +585,11 @@ pub enum DataKey {
     WasmUpgradeProposal,
     /// Configurable maximum release window (in seconds)
     MaxReleaseWindow,
+    /// Configurable maximum number of escrows accepted per batch call (Issue #1074).
+    BatchSizeLimit,
+    /// Configurable ceiling on the expected storage work (persistent writes) of
+    /// a single batch call (Issue #1074).
+    BatchResourceBudget,
     /// Address of the deployed onboarding contract for cross-contract reputation calls
     OnboardingContractAddress,
     /// DEPRECATED legacy storage: Map of whitelisted token addresses (Address -> bool).
@@ -3343,6 +3361,79 @@ impl CraftNexusContract {
     pub fn get_min_release_window(env: Env) -> u32 {
         let config = Self::get_platform_config_internal(&env);
         config.min_release_window
+    }
+
+    /// Get the configured maximum number of escrows accepted per batch call
+    /// (Issue #1074). Falls back to [`batch_bounds::DEFAULT_BATCH_SIZE_LIMIT`]
+    /// when no explicit ceiling has been configured.
+    pub fn get_batch_size_limit(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::BatchSizeLimit)
+            .unwrap_or(batch_bounds::DEFAULT_BATCH_SIZE_LIMIT)
+    }
+
+    /// Set the maximum number of escrows accepted per batch call (admin only).
+    ///
+    /// Batch methods validate the item count against this ceiling *before* any
+    /// escrow is created or funds move, so oversized requests fail with
+    /// `Error::BatchLimitExceeded` before state changes (Issue #1074).
+    ///
+    /// # Panics
+    /// - If the caller is not the admin.
+    /// - If `limit` is below `batch_bounds::MIN_BATCH_SIZE_LIMIT` or above
+    ///   `batch_bounds::MAX_BATCH_SIZE_LIMIT`, which would permit batches that
+    ///   risk breaching the Soroban resource envelope.
+    pub fn set_batch_size_limit(env: Env, limit: u32) {
+        let config = Self::get_platform_config_internal(&env);
+        config.admin.require_auth();
+
+        if limit < batch_bounds::MIN_BATCH_SIZE_LIMIT
+            || limit > batch_bounds::MAX_BATCH_SIZE_LIMIT
+        {
+            env.panic_with_error(crate::Error::BatchLimitExceeded);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::BatchSizeLimit, &limit);
+        Self::extend_persistent(&env, &DataKey::BatchSizeLimit);
+    }
+
+    /// Get the configured ceiling on the expected storage work (persistent
+    /// writes) of a single batch call (Issue #1074). Falls back to
+    /// [`batch_bounds::DEFAULT_BATCH_STORAGE_WRITES_BUDGET`] when unset.
+    pub fn get_batch_resource_budget(env: Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::BatchResourceBudget)
+            .unwrap_or(batch_bounds::DEFAULT_BATCH_STORAGE_WRITES_BUDGET)
+    }
+
+    /// Set the ceiling on the expected storage work (persistent writes) of a
+    /// single batch call (admin only).
+    ///
+    /// A batch whose [`batch_bounds::expected_storage_writes`] exceeds this
+    /// budget is rejected with `Error::BatchResourceLimitExceeded` *before* any
+    /// escrow is created or funds move, giving the admin a deterministic
+    /// resource budget independent of the item-count ceiling (Issue #1074).
+    ///
+    /// # Panics
+    /// - If the caller is not the admin.
+    /// - If `budget` is below `batch_bounds::MIN_BATCH_STORAGE_WRITES_BUDGET`
+    ///   (prevents accidentally disabling batch creation).
+    pub fn set_batch_resource_budget(env: Env, budget: u64) {
+        let config = Self::get_platform_config_internal(&env);
+        config.admin.require_auth();
+
+        if budget < batch_bounds::MIN_BATCH_STORAGE_WRITES_BUDGET {
+            env.panic_with_error(crate::Error::BatchResourceLimitExceeded);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::BatchResourceBudget, &budget);
+        Self::extend_persistent(&env, &DataKey::BatchResourceBudget);
     }
 
     /// Register the deployed OnboardingContract address so the escrow contract
@@ -8563,7 +8654,8 @@ impl CraftNexusContract {
     ) -> Map<u32, Error> {
         let mut errors: Map<u32, Error> = Map::new(&env);
 
-        if escrows.len() > MAX_BATCH_SIZE {
+        // Issue #1074: honor the configured batch size ceiling.
+        if escrows.len() > Self::get_batch_size_limit(&env) {
             env.panic_with_error(crate::Error::BatchLimitExceeded);
         }
 
@@ -8590,19 +8682,37 @@ impl CraftNexusContract {
     /// - Batch size limit to prevent resource exhaustion
     ///
     /// # Arguments
-    /// * `escrows` - Vector of escrow creation parameters (max MAX_BATCH_SIZE items)
+    /// * `escrows` - Vector of escrow creation parameters. The item count and
+    ///   expected storage work are validated against the configured batch
+    ///   bounds (`get_batch_size_limit` / `get_batch_resource_budget`) before
+    ///   any escrow is created or funds move (Issue #1074).
     /// * `batch_id` - Unique identifier for this batch operation
     ///
     /// # Returns
     /// Vector of created escrow IDs
     ///
     /// # Errors
-    /// - BatchLimitExceeded if batch exceeds MAX_BATCH_SIZE
+    /// - BatchLimitExceeded if the batch item count exceeds the configured
+    ///   batch size limit
+    /// - BatchResourceLimitExceeded if the batch's expected storage work
+    ///   exceeds the configured batch resource budget
     /// - Any validation error from individual escrows
     pub fn create_escrows_batch(
         env: Env,
         params: soroban_sdk::Vec<EscrowCreateParams>,
     ) -> Result<soroban_sdk::Vec<u64>, Error> {
+        Self::check_not_paused(&env);
+
+        // Issue #1074: validate the work size BEFORE allocating the batch id so
+        // an oversized request fails without any state change at all.
+        // `create_batch_escrow` re-applies the same gate as defense-in-depth
+        // for direct callers and continuation chunks.
+        batch_bounds::ensure_batch_within_bounds(
+            params.len(),
+            Self::get_batch_size_limit(&env),
+            Self::get_batch_resource_budget(&env),
+        )?;
+
         let batch_id = env
             .storage()
             .instance()
@@ -8622,10 +8732,18 @@ impl CraftNexusContract {
         let _guard = ReentryGuardScope::new(&env);
         Self::check_not_paused(&env);
 
-        // Issue #111: Enforce batch size limit
-        if escrows.len() > MAX_BATCH_SIZE {
-            return Err(Error::BatchLimitExceeded);
-        }
+        // Issue #1074: bound the work size BEFORE any escrow is created or any
+        // funds move. The item count is compared against the admin-configurable
+        // batch size ceiling and the expected storage work against the
+        // admin-configurable resource budget. Rejecting here keeps the whole
+        // batch (and every continuation chunk, which funnels through this
+        // function) from mutating state or burning the Soroban budget on an
+        // oversized request.
+        batch_bounds::ensure_batch_within_bounds(
+            escrows.len(),
+            Self::get_batch_size_limit(&env),
+            Self::get_batch_resource_budget(&env),
+        )?;
 
         let mut results = soroban_sdk::Vec::new(&env);
 
@@ -8816,9 +8934,21 @@ impl CraftNexusContract {
         Self::check_not_paused(&env);
         owner.require_auth();
 
-        if params.is_empty() || params.len() > MAX_BATCH_SIZE {
+        if params.is_empty() {
             return Err(Error::BatchLimitExceeded);
         }
+
+        // Issue #1074: reject schedules whose estimated total work exceeds the
+        // configured bounds before persisting the job. The item count is
+        // checked against the admin-configurable batch size ceiling and the
+        // expected storage work against the admin-configurable resource
+        // budget. Continuation chunks later funnel through
+        // `create_batch_escrow`, which applies the same gate on every resume.
+        batch_bounds::ensure_batch_within_bounds(
+            params.len(),
+            Self::get_batch_size_limit(&env),
+            Self::get_batch_resource_budget(&env),
+        )?;
 
         let mut authorized_buyers: Map<Address, u32> = Map::new(&env);
         for i in 0..params.len() {


### PR DESCRIPTION
# Make Batch Operations Explicitly Bounded

Closes #1074

## Summary

Batch escrow methods now reject work sizes that exceed **configured, admin-settable** contract resource budgets **before** any escrow is created or any funds move. Previously the item-count ceiling was a hard-coded constant (`MAX_BATCH_SIZE`) and the *expected storage work* of a batch was never validated up front — an oversized request would only fail (if at all) mid-loop against the Soroban resource envelope.

This change makes both bounds explicit and configurable, and validates them as a pure pre-flight on every batch boundary.

## What changed

### New module: `craft-nexus-contract/src/batch_bounds.rs`
Centralizes the two bounded axes:

- **Item-count ceiling** — `set_batch_size_limit` / `get_batch_size_limit`. Defaults to the legacy `MAX_BATCH_SIZE` (20) so out-of-the-box behavior is unchanged; admin may configure between `MIN_BATCH_SIZE_LIMIT` (1) and `MAX_BATCH_SIZE_LIMIT` (100).
- **Expected storage-work budget** — `set_batch_resource_budget` / `get_batch_resource_budget`. A conservative per-escrow storage-write estimate (`STORAGE_WRITES_PER_ESCROW`) × item count, compared against the configured ceiling. Default budget (240 writes) exactly admits a full default-sized batch; admins can tighten it independently of the item-count limit.

Providing the pure, side-effect-free gate `ensure_batch_within_bounds(count, size_limit, budget)`:

- `item_count > size_limit` → `Error::BatchLimitExceeded`
- `expected_storage_writes(item_count) > storage_budget` → `Error::BatchResourceLimitExceeded`

### Enforcement points (all **before** mutation)
- `create_escrows_batch` — gates before the batch id is allocated (zero state change on rejection).
- `create_batch_escrow` — gates before the first `create_single_escrow`; this is the shared chokepoint for the one-shot path **and** every `continue_batch_escrow` chunk.
- `schedule_batch_escrow` — gates before the job is persisted.
- `validate_batch_creation` — honors the configured ceiling instead of the constant.

### New error + catalog
- `Error::BatchResourceLimitExceeded = 87` (documented in `docs/ERROR_CATALOG.md`).

## Acceptance criteria

| Criterion | Status |
|---|---|
| Oversized requests fail before state changes | ✅ gates run before any storage write / token transfer in every batch method |
| Limits are configurable and documented | ✅ two admin setters/getters + module docs + error catalog |
| Valid batches preserve current ordering and semantics | ✅ defaults match the legacy `MAX_BATCH_SIZE` semantics; clear ordering and batch flow code untouched |

## Example

```text
set_batch_size_limit(10)            # admin: cap batches at 10 items
create_escrows_batch([...11 items]) -> Error::BatchLimitExceeded   (nothing created)
set_batch_resource_budget(48)       # admin: tighten storage-work budget
create_escrows_batch([...5 items])  -> Error::BatchResourceLimitExceeded (est. 60 writes > 48, nothing created)
```

## Testing

Added pure unit tests in `batch_bounds.rs` covering the default/empty-batch edge cases and both rejection paths. Note: `cargo test` was not executed in this environment — CI should run the full suite.