### PR TITLE
test(onboarding): verify non-admin queue access is rejected

### DIFF
--- a/craft-nexus-contract/src/onboarding.rs
+++ b/craft-nexus-contract/src/onboarding.rs
@@ -4931,7 +4931,8 @@ impl OnboardingContract {
     /// None.
     ///
     /// # Errors
-    /// None.
+    /// - Panics with [`Error::NotInitialized`] when the contract configuration is absent.
+    /// - Fails authorization unless the configured `platform_admin` signs the invocation.
     pub fn get_verification_queue(env: Env) -> Vec<Address> {
         let config: OnboardingConfig = env
             .storage()

--- a/craft-nexus-contract/src/onboarding_test.rs
+++ b/craft-nexus-contract/src/onboarding_test.rs
@@ -2,7 +2,7 @@ use super::decimal_test_token::{DecimalTestToken, DecimalTestTokenClient};
 use super::*;
 use crate::alloc::string::ToString;
 use soroban_sdk::{
-    testutils::{storage::Persistent as _, Address as _, Ledger},
+    testutils::{storage::Persistent as _, Address as _, Ledger, MockAuth, MockAuthInvoke},
     token, Address, Bytes, Env, String, Symbol,
 };
 
@@ -3100,11 +3100,11 @@ fn test_set_moderator_unknown_user_panics() {
 #[should_panic]
 fn test_get_verification_queue_non_admin_rejected() {
     let env = Env::default();
-    // Do NOT call mock_all_auths — no auth provided.
 
     let contract_id = env.register_contract(None, OnboardingContract);
     let client = OnboardingContractClient::new(&env, &contract_id);
     let admin = Address::generate(&env);
+    let non_admin = Address::generate(&env);
 
     let config = OnboardingConfig {
         require_username: true,
@@ -3120,9 +3120,19 @@ fn test_get_verification_queue_non_admin_rejected() {
         env.storage().persistent().set(&DataKey::Config, &config);
     });
 
-    // No auth signal — must panic immediately.
-    client.get_verification_queue();
-    let _ = admin;
+    // Supplying a valid authorization for a different address must not satisfy
+    // the configured platform admin's require_auth() check.
+    client
+        .mock_auths(&[MockAuth {
+            address: &non_admin,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "get_verification_queue",
+                args: soroban_sdk::Vec::new(&env),
+                sub_invokes: &[],
+            },
+        }])
+        .get_verification_queue();
 }
 
 /// Issue #474 — admin receives the queue and the auth signal is recorded.


### PR DESCRIPTION
Closes #615

## Context

The production-side protection requested by this issue is already present on `main` through #578: `get_verification_queue` calls `config.platform_admin.require_auth()` before queue advancement or iteration. Per-entry queue TTL refresh and its positive coverage were added in #912.

The remaining misleading gap was `test_get_verification_queue_non_admin_rejected`: despite its name, it supplied no authorization at all, duplicating the no-auth test. The older #693 also accumulated a very large unrelated diff and recurring conflicts.

## Changes

- Supply valid mocked authorization from a distinct non-admin address and assert that it cannot satisfy the configured admin authorization.
- Correct the endpoint error documentation to describe missing configuration and admin authorization failures.
- Keep the change to two onboarding files; no production behavior, storage, or snapshot changes.

## Verification

- `git diff --check upstream/main...HEAD` passes.
- On the last known green #912 source baseline, with the repository current pinned Cargo dependencies, `cargo test test_get_verification_queue_non_admin_rejected --locked -- --nocapture` passes: 1 passed, 0 failed, and the call is rejected with `HostError: Error(Auth, InvalidAction)`.
- The current upstream `main` cannot run `cargo check --tests` or `cargo test` independently of this PR because `craft-nexus-contract/src/lib.rs` contains committed merge-conflict markers and a truncated error string from unrelated merged work (notably #1105). Open #1168 currently does not fully restore parsability either. I deliberately did not mix that repository-wide repair into this security regression PR, since unrelated changes and conflicts were the reason #693 became unreviewable.